### PR TITLE
Get initial customer when there is no state, rather than onload

### DIFF
--- a/src/tutorials/accountDetail/accountDetail.js
+++ b/src/tutorials/accountDetail/accountDetail.js
@@ -18,6 +18,7 @@ function getState(){
 		field: 'accountNumber',
 	}, function (err, state) {
 		if (state === null) {
+			getInitialCustomer();
 			return;
 		}
 		setAccountNumber(state);
@@ -54,7 +55,6 @@ function getInitialCustomer(){
 }
 
 FSBL.addEventListener("onReady", function () {
-	getInitialCustomer();
 	listenForCustomer();
 	communicateBetweenComponents();
 	getState();


### PR DESCRIPTION
This was preventing state restore from working correctly.