### PR TITLE
Add no build

### DIFF
--- a/build/webpack/defaultWebpackConfig.js
+++ b/build/webpack/defaultWebpackConfig.js
@@ -1,8 +1,22 @@
 const path = require('path');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const { DefinePlugin } = require("webpack"); 
+const { DefinePlugin } = require("webpack");
 
 const env = process.env.NODE_ENV ? process.env.NODE_ENV : "development";
+
+const plugins =
+	[
+		new DefinePlugin({
+			"process.env": {
+				"NODE_ENV": JSON.stringify(env)
+			}
+		})
+	]
+
+if (env === "production") {
+	// When building the production environment, minify the code.
+	plugins.push(new UglifyJsPlugin());
+}
 
 module.exports = function () {
 	return {
@@ -60,14 +74,7 @@ module.exports = function () {
 				}
 			]
 		},
-		plugins: [
-			new DefinePlugin({
-				"process.env": {
-			  		"NODE_ENV": JSON.stringify(env)
-				}
-		  	}),
-			new UglifyJsPlugin(),
-		],
+		plugins: plugins,
 		output: {
 			filename: "[name].js",
 			sourceMapFilename: "[name].map.js",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -50,12 +50,12 @@
 	// #endregion
 
 	// #region Task Methods
-	/** 
-	 * Object containing all of the methods used by the gulp tasks. 
+	/**
+	 * Object containing all of the methods used by the gulp tasks.
 	 */
 	const taskMethods = {
-		/** 
-		 * Builds the SASS files for the project. 
+		/**
+		 * Builds the SASS files for the project.
 		 */
 		buildSass: () => {
 			return gulp
@@ -85,7 +85,7 @@
 			return del(distPath, { force: true });
 		},
 
-		/** 
+		/**
 		 * Copies static files to the output directory.
 		 */
 		copyStaticFiles: () => {
@@ -149,21 +149,21 @@
 
 		/**
 		 * Method called after tasks are defined.
-		 * @param done Callback function used to signal function completion to support asynchronous execution. Can 
+		 * @param done Callback function used to signal function completion to support asynchronous execution. Can
 		 * optionally return an error, if one occurs.
 		 */
 		post: done => { done(); },
 
 		/**
 		 * Method called before tasks are defined.
-		 * @param done Callback function used to signal function completion to support asynchronous execution. Can 
+		 * @param done Callback function used to signal function completion to support asynchronous execution. Can
 		 * optionally return an error, if one occurs.
 		 */
 		pre: done => { done(); },
 
 		/**
 		 * Starts the server.
-		 * 
+		 *
 		 * @param {function} done Function called when execution has completed.
 		 */
 		startServer: done => {
@@ -204,7 +204,7 @@
 			serverExec.stderr.on("data", data => { console.error(errorOutColor(`ERROR: ${data}`)); });
 		},
 
-		/** 
+		/**
 		 * Watches files for changes to fire off copies and builds.
 		 */
 		watchFiles: done => {
@@ -263,7 +263,8 @@
 		 * Specifies the default task to run if no task is passed in.
 		 */
 		gulp.task("default", gulp.series("dev:run"));
-
+		/** Launches the application without building the files. For tsting prod builds. */
+		gulp.task("dev:no-build", gulp.series(taskMethods.startServer, taskMethods.launchApplication))
 		taskMethods.post(err => {
 			if (err) {
 				console.error(err);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "prod": "set NODE_ENV=production&&gulp prod --gulpfile=./gulpfile.js",
     "build": "set NODE_ENV=development&&gulp build --gulpfile=./gulpfile.js",
     "build:prod": "set NODE_ENV=production&&gulp build --gulpfile=./gulpfile.js",
+    "dev:no-build": "set NODE_ENV=production&&gulp dev:no-build --gulpfile=./gulpfile.js",
     "clean": "gulp clean --gulpfile=./gulpfile.js",
     "update-finsemble": "npm update @chartiq/finsemble && npm update -g @chartiq/finsemble-cli"
   },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "set NODE_ENV=development&&gulp --gulpfile=./gulpfile.js",
     "prod": "set NODE_ENV=production&&gulp prod --gulpfile=./gulpfile.js",
-    "build": "gulp build --gulpfile=./gulpfile.js",
+    "build": "set NODE_ENV=development&&gulp build --gulpfile=./gulpfile.js",
+    "build:prod": "set NODE_ENV=production&&gulp build --gulpfile=./gulpfile.js",
     "clean": "gulp clean --gulpfile=./gulpfile.js",
     "update-finsemble": "npm update @chartiq/finsemble && npm update -g @chartiq/finsemble-cli"
   },


### PR DESCRIPTION
Adds a command that allows user to spin up the server and launch openfin without building all of the files. This is useful for testing the results of `build:prod`.