### PR TITLE
Add timeout in the server to attempt to capture failed startup. 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -250,8 +250,12 @@
 				})
 				.then(() => {
 					// OpenFin has closed so exit gulpfile
+					logToTerminal("yellow", "Openfin has closed.");
 					if (watchClose) watchClose();
 					process.exit();
+				})
+				.catch(e => {
+					logToTerminal("red", `Openfin error:${JSON.stringify(e)}`)
 				});
 
 			done();


### PR DESCRIPTION
Add a catch to the launchOpenfin promise chain to log any errors. Log when openfin closes.