### PR TITLE
#7368 disable tabs per component

### DIFF
--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -170,7 +170,6 @@ var Actions = {
 
 			windowTitleBarStore.setValues([{ field: "AlwaysOnTop.show", value: alwaysOnTopIcon }]);
 
-			debugger;
 			if (typeof windowTitleBarConfig.showTabs !== 'boolean') {
 				windowTitleBarStore.setValue({ field: "showTabs", value: globalWindowManagerConfig.showTabs });
 			}

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -40,6 +40,10 @@ var Actions = {
 				{ field: "AlwaysOnTop.show", value: FSBLHeader.alwaysOnTop ? true : false },
 			]);
 
+			if (windowTitleBarConfig.showTabs || windowTitleBarConfig.showTabs === false) {
+				windowTitleBarStore.setValue({ field: "showTabs", value: windowTitleBarConfig.showTabs });
+			}
+
 			// Set by calling WindowClient.setTitle() || from config "foreign.components.Window Manager.title"
 			var title = FSBL.Clients.WindowClient.title || windowTitleBarConfig.title;
 

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -152,12 +152,8 @@ var Actions = {
 		//default title.
 		windowTitleBarStore.setValue({ field: "Main.windowTitle ", value: FSBL.Clients.WindowClient.getWindowTitle() });
 
-		/**
-		 * If docking is disabled, don't show buttons on snaps.
-		 * @todo remove once docking is out of beta.
-		 */
 		FSBL.Clients.ConfigClient.getValue({ field: "finsemble" }, function (err, finsembleConfig) {
-			let globalWindowManagerConfig = finsembleConfig["Window Manager"] || { alwaysOnTopIcon: false }; // Override defaults if finsemble.Window Manager exists.
+			let globalWindowManagerConfig = finsembleConfig["Window Manager"] || { alwaysOnTopIcon: false, showTabs: false }; // Override defaults if finsemble.Window Manager exists.
 
 			// Look to see if docking is enabled. Cascade through backward compatibility with old "betaFeatures" and then a default if no config is found at all.
 			let dockingConfig = finsembleConfig.docking;
@@ -173,6 +169,11 @@ var Actions = {
 				alwaysOnTopIcon = windowTitleBarConfig.alwaysOnTopIcon;
 
 			windowTitleBarStore.setValues([{ field: "AlwaysOnTop.show", value: alwaysOnTopIcon }]);
+
+			debugger;
+			if (typeof windowTitleBarConfig.showTabs !== 'boolean') {
+				windowTitleBarStore.setValue({ field: "showTabs", value: globalWindowManagerConfig.showTabs });
+			}
 		});
 
 		Actions.getInitialTabList((err, values) => {

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -82,6 +82,7 @@ class WindowTitleBar extends React.Component {
 
 		this.onShareEmitterChanged = this.onShareEmitterChanged.bind(this);
 		this.onTabsChanged = this.onTabsChanged.bind(this);
+		this.onShowTabsChanged = this.onShowTabsChanged.bind(this);
 
 	}
 	componentWillMount() {
@@ -94,16 +95,9 @@ class WindowTitleBar extends React.Component {
 			{ field: "Linker.showLinkerButton", listener: this.showLinkerButton },
 			{ field: "Sharer.emitterEnabled", listener: this.onShareEmitterChanged },
 			{ field: "isTopRight", listener: this.isTopRight },
-			{ field: "tabs", listener: this.onTabsChanged }
+			{ field: "tabs", listener: this.onTabsChanged },
+			{ field: "showTabs", listener: this.onShowTabsChanged },
 		]);
-
-		if (typeof this.state.showTabs !== 'boolean') {
-			FSBL.Clients.ConfigClient.getValue({ field: "finsemble.Window Manager.showTabs" }, (err, showTabs) => {
-				this.setState({
-					showTabs: showTabs ? true : false
-				});
-			});
-		}
 
 		FSBL.Clients.RouterClient.addListener("DockingService.startTilingOrTabbing", this.disallowDragOnCenterRegion);
 		console.log("Adding listener for stopTilingOrTabbing.");
@@ -128,7 +122,8 @@ class WindowTitleBar extends React.Component {
 			{ field: "Linker.showLinkerButton", listener: this.showLinkerButton },
 			{ field: "Sharer.emitterEnabled", listener: this.onShareEmitterChanged },
 			{ field: "isTopRight", listener: this.isTopRight },
-			{ field: "tabs", listener: this.onTabsChanged }
+			{ field: "tabs", listener: this.onTabsChanged },
+			{ field: "showTabs", listener: this.onShowTabsChanged },
 		]);
 		console.log("Removing listener from the router.");
 		FSBL.Clients.RouterClient.removeListener("DockingService.startTilingOrTabbing", this.disallowDragOnCenterRegion);
@@ -223,6 +218,13 @@ class WindowTitleBar extends React.Component {
 	onTabsChanged(err, response) {
 		this.setState({
 			tabs: response.value
+		})
+	}
+
+	onShowTabsChanged(err, response) {
+		debugger;
+		this.setState({
+			showTabs: response.value
 		})
 	}
 

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -57,7 +57,7 @@ class WindowTitleBar extends React.Component {
 			isTopRight: windowTitleBarStore.getValue({ field: "isTopRight" }),
 			alwaysOnTopButton: windowTitleBarStore.getValue({ field: "AlwaysOnTop.show" }),
 			tabs: [{ title: windowTitleBarStore.getValue({ field: "Main.windowTitle" }) }], //array of tabs for this window
-			showTabs: false,
+			showTabs: windowTitleBarStore.getValue({field: "showTabs"}),
 			allowDragOnCenterRegion: true,
 			activeTab: FSBL.Clients.WindowClient.getWindowIdentifier(),
 			tabBarBoundingBox: {},
@@ -97,12 +97,13 @@ class WindowTitleBar extends React.Component {
 			{ field: "tabs", listener: this.onTabsChanged }
 		]);
 
-		FSBL.Clients.ConfigClient.getValue({ field: "finsemble" }, (err, config) => {
-			let windowManager = config['Window Manager'];
-			this.setState({
-				showTabs: typeof config['Window Manager'] !== undefined ? config['Window Manager'].showTabs : false
+		if (typeof this.state.showTabs !== 'boolean') {
+			FSBL.Clients.ConfigClient.getValue({ field: "finsemble.Window Manager.showTabs" }, (err, showTabs) => {
+				this.setState({
+					showTabs: showTabs ? true : false
+				});
 			});
-		})
+		}
 
 		FSBL.Clients.RouterClient.addListener("DockingService.startTilingOrTabbing", this.disallowDragOnCenterRegion);
 		console.log("Adding listener for stopTilingOrTabbing.");
@@ -274,7 +275,7 @@ class WindowTitleBar extends React.Component {
 							tabs={this.state.tabs}
 							ref="tabArea"
 						/>}
-					
+
 				</div>
 				<div className={rightWrapperClasses} ref={this.setToolbarRight}>
 					{this.state.alwaysOnTopButton && showMinimizeIcon ? <AlwaysOnTop /> : null}

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -222,7 +222,6 @@ class WindowTitleBar extends React.Component {
 	}
 
 	onShowTabsChanged(err, response) {
-		debugger;
 		this.setState({
 			showTabs: response.value
 		})


### PR DESCRIPTION
Window Title bar was not reading config from the component to override global setting setting for showTabs. Fixed by only using global setting if local setting does not exist. Tested with both global false, local true and vice versa.