### PR TITLE
Fixes pins with icons not showing titles

### DIFF
--- a/src-built-in/components/assets/css/_toolbar.css
+++ b/src-built-in/components/assets/css/_toolbar.css
@@ -133,6 +133,7 @@
 img.pinned-icon {
     padding-top: var(--pinned-icon-padding-top);
     max-width: 17px;
+    float: left;
 }
 
 .pinned-icon {

--- a/src-built-in/components/toolbar/src/dynamicToolbar.jsx
+++ b/src-built-in/components/toolbar/src/dynamicToolbar.jsx
@@ -151,6 +151,7 @@ export default class Toolbar extends React.Component {
 			}
 
 			var sectionComponent = (<FinsembleToolbarSection
+				key={i}
 				arrangeable={sectionPosition === "center"}
 				ref="pinSection"
 				name={sectionPosition}


### PR DESCRIPTION
Also fixes a react warning (which could potentially lead to rendering errors) in the dynamicToolbar