### PR TITLE
Save active workspace when saveAs/new/export workspace

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -353,6 +353,7 @@ export default class Workspaces extends React.Component {
 				}
 			});
 		}
+
 		//If we're autosaving, autosave, then export.
 		//@todo, put into store. consider moving autosave into workspaceClient.
 		FSBL.Clients.ConfigClient.getValue({ field: "finsemble.preferences.workspaceService.promptUserOnDirtyWorkspace" }, (err, data) => {

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -26,6 +26,19 @@ function uuidv4() {
 }
 let finWindow = fin.desktop.Window.getCurrent();
 Actions = {
+	autoSave: (callback) => {
+		let activeName = FSBL.Clients.WorkspaceClient.activeWorkspace.name;
+		if (!PROMPT_ON_SAVE) {
+			FSBL.Clients.WorkspaceClient.saveAs({
+				name: activeName,
+				force: true
+			}, (err, response) => {
+				callback(err);
+			});
+		} else {
+			callback(null);
+		}
+	},
 	initialize: function () {
 		//Gets the workspace list and sets the value in the store.
 		FSBL.Clients.WorkspaceClient.getWorkspaces(function (err, workspaces) {
@@ -139,11 +152,14 @@ Actions = {
 			});
 		}
 
+
 		if (!newWorkspaceDialogIsActive) {
 			WorkspaceManagementStore.setValue({ field: "newWorkspaceDialogIsActive", value: true });
 		}
+
 		Actions.blurWindow();
 		let tasks = [
+			Actions.autoSave,
 			Actions.spawnWorkspaceInputField,
 			Actions.validateWorkspaceInput,
 			Actions.checkIfWorkspaceAlreadyExists,
@@ -297,6 +313,7 @@ Actions = {
 		Logger.system.log("SaveWorkspaceAs clicked.");
 
 		async.waterfall([
+			Actions.autoSave,
 			Actions.spawnSaveAsDialog,
 			Actions.validateWorkspaceInput,
 			Actions.checkIfWorkspaceAlreadyExists,
@@ -330,21 +347,12 @@ Actions = {
 			}, callback);
 		}
 
-		function autoSave(callback) {
-			let activeName = FSBL.Clients.WorkspaceClient.activeWorkspace.name;
-			FSBL.Clients.WorkspaceClient.saveAs({
-				name: activeName,
-				force: true
-			}, (err, response) => {
-				callback(err, null);
-			});
-		}
 		/**
 		 * If the workspace is dirty, we need to do more than if it's clean. We don't want users to lose unsaved work.
 		 */
 		let tasks = [];
 		if (activeWorkspace.isDirty) {
-			let firstMethod = autoSave,
+			let firstMethod = Actions.autoSave,
 				secondMethod = null;
 			if (PROMPT_ON_SAVE === true) {
 				//We want to ask the user to save. But if they're trying to reload the workspace, the mssage needs to be different. The first if block just switches that method.


### PR DESCRIPTION
 On saveAs, new Workspace, and export, check to see if autosave is enabled. If so, save the workspace before performing the action.

We should consider moving this functionality into the workspaceClient API. For now, the responsibility lies with the UI.