### PR TITLE
Added a user preference for switching toolbar monitor.

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/General.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/General.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Store as UserPreferencesStore } from "../../stores/UserPreferencesStore";
 import ScheduledRestart from "../general/ScheduledRestart";
+import Toolbar from "../general/Toolbar";
 export default class General extends React.Component {
     constructor(props) {
         super(props);
     }
     render() {
         return <div>
-            <ScheduledRestart/>
+            <ScheduledRestart />
+            <Toolbar />
          </div>
     }
 }

--- a/src-built-in/components/userPreferences/src/components/general/Toolbar.jsx
+++ b/src-built-in/components/userPreferences/src/components/general/Toolbar.jsx
@@ -11,7 +11,7 @@ export default class Toolbar extends React.Component {
 	}
 
     /**
-     * Sets the meridiem for the time (AM or PM). Afterwards, this calls setHour to handle any necessary conversions to military time.
+     * Sets the monitor by calling the setPreferences API. This will override the config for the component.
      * @param {event} e
      */
 	setMonitor(e) {

--- a/src-built-in/components/userPreferences/src/components/general/Toolbar.jsx
+++ b/src-built-in/components/userPreferences/src/components/general/Toolbar.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+export default class Toolbar extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {
+			monitor: "all"
+		};
+		this.setMonitor = this.setMonitor.bind(this);
+		this.restartApplication = this.restartApplication.bind(this);
+	}
+
+    /**
+     * Sets the meridiem for the time (AM or PM). Afterwards, this calls setHour to handle any necessary conversions to military time.
+     * @param {event} e
+     */
+	setMonitor(e) {
+		let monitor = e.target.value;
+		this.setState({
+			monitor: monitor
+		});
+		FSBL.Clients.ConfigClient.setPreference({ field: "finsemble.components.Toolbar.window.monitor", value: monitor });
+		// There's no need to override spawnOnAllMonitors. Setting monitor to anything other than undefined will automatically override that value. Setting monitor="all" is equivalent.
+	}
+
+	restartApplication() {
+		FSBL.restartApplication();
+	}
+
+    /**
+     * Add listener on the store. When the preferences field changes, we change our local state.
+     * Also, get the intiial state from the store.
+     */
+	componentDidMount() {
+		FSBL.Clients.ConfigClient.getValue("finsemble.components.Toolbar.window.monitor", (err, value) => {
+			if (!value) value = "all";
+			this.setState({
+				monitor: value
+			});
+		});
+	}
+
+	componentWillUnmount() {
+	}
+
+	render() {
+		return <div className="complex-menu-content-row">
+			<div>
+				<span>Toolbar Monitor (requires restart)</span>
+				<select style={{ margin: "0px 10px" }} onChange={this.setMonitor} value={this.state.monitor}>
+					<option value={"all"}>All</option>
+					<option value={"0"}>Primary</option>
+					<option value={"1"}>2</option>
+					<option value={"2"}>3</option>
+					<option value={"3"}>4</option>
+					<option value={"4"}>5</option>
+					<option value={"5"}>6</option>
+				</select>
+				<button onClick={this.restartApplication}>Restart Application</button>
+			</div>
+		</div>
+	}
+}


### PR DESCRIPTION
Adds a user preference for selecting which monitor the toolbar appears on. User must restart for it to take effect (and they must restart with the button to ensure that localStorage is available).