### PR TITLE
7295 Adds showWarningForLogStates prop to config for logger service

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -16,6 +16,9 @@
 				"title": "App Catalog",
 				"component": "App Catalog"
 			}
+		},
+		"logger": {
+			"showWarningForLogStates": ["Info", "Debug", "Verbose"]
 		}
 	},
 	"systemTrayIcon": "$applicationRoot/components/assets/img/Finsemble_Taskbar_Icon.png",


### PR DESCRIPTION
This will allow the user to easily change the log states which will throw a warning


Finsemble PR: https://github.com/ChartIQ/finsemble/pull/802