### PR TITLE
7936 - Make titlebars 25px

### DIFF
--- a/src-built-in/components/assets/css/_theme.css
+++ b/src-built-in/components/assets/css/_theme.css
@@ -48,7 +48,7 @@
     --toolbar-separator: 1px solid rgba(255, 255, 255, 0.3);
     
     /* Window Title bar */
-    --titleBar-height: 32px;
+    --titleBar-height: 25px;
     --titleBar-font-size: 14px;
     --titleBar-icon-font-size: 15px;
     --titleBar-active-font-color: var(--primary-font-color);

--- a/src-built-in/components/assets/css/_theme.css
+++ b/src-built-in/components/assets/css/_theme.css
@@ -50,7 +50,7 @@
     /* Window Title bar */
     --titleBar-height: 25px;
     --titleBar-font-size: 14px;
-    --titleBar-icon-font-size: 15px;
+    --titleBar-icon-font-size: 14px;
     --titleBar-active-font-color: var(--primary-font-color);
     --titleBar-inactive-font-color: var(--gray3);
     --titleBar-font-weight: var(--primary-font-weight);

--- a/src-built-in/components/assets/css/_windowTitleBar.css
+++ b/src-built-in/components/assets/css/_windowTitleBar.css
@@ -246,9 +246,9 @@ html.desktop-active .fsbl-icon-highlighted {
 }
 
 .linker-group {
-    width: 7px;
-    height: 18px;
-    margin-left: 4px;
+    width: 5px;
+    height: 15px;
+    margin-left: 3px;
     border-radius: 4px;
     border: 1px solid var(--titleBar-background-inactive-color);
 }

--- a/src-built-in/components/assets/css/_windowTitleBar.css
+++ b/src-built-in/components/assets/css/_windowTitleBar.css
@@ -173,7 +173,7 @@ html.desktop-active .fsbl-tab-region-drag-area {
     position: relative;
     color: var(--titleBar-inactive-font-color);
     font-size: var(--titleBar-icon-font-size);
-    width: 21px;
+    width: 18px;
     padding: 0px 6px;
     height: calc(100% + 5px);
     margin-top: -5px;
@@ -289,7 +289,7 @@ html.desktop-active .fsbl-linker[hover=true] {
 }
 
 .ff-minimize {
-    padding-bottom: 5px;
+    padding-bottom: 3px;
 }
 
 .ff-linker:before {
@@ -307,6 +307,10 @@ html.desktop-active .fsbl-linker[hover=true] {
 .ff-always-on-top {
     padding-top: 3px;
     font-size: 16px;
+}
+
+.ff-restore {
+    padding-top: 4px;
 }
 
 .fsbl-tab {
@@ -381,6 +385,7 @@ html.desktop-active .fsbl-linker[hover=true] {
 
 .fsbl-tab-logo {
     margin: 0 7px;
+    padding-top: 3px;
     width: auto;
     height: auto;
     color: var(--titlebar-tab-icon-font-color);

--- a/src-built-in/components/assets/css/_windowTitleBar.css
+++ b/src-built-in/components/assets/css/_windowTitleBar.css
@@ -391,6 +391,10 @@ html.desktop-active .fsbl-linker[hover=true] {
     color: var(--titlebar-tab-icon-font-color);
 }
 
+.fsbl-tab-logo i {
+    font-size: 14px;
+}
+
 .fsbl-tab-logo img {
     height: 18px;
     width: 18px;

--- a/src-built-in/components/assets/css/_windowTitleBar.css
+++ b/src-built-in/components/assets/css/_windowTitleBar.css
@@ -385,7 +385,7 @@ html.desktop-active .fsbl-linker[hover=true] {
 
 .fsbl-tab-logo {
     margin: 0 7px;
-    padding-top: 3px;
+    padding-top: 1px;
     width: auto;
     height: auto;
     color: var(--titlebar-tab-icon-font-color);

--- a/src-built-in/components/assets/css/_windowTitleBar.css
+++ b/src-built-in/components/assets/css/_windowTitleBar.css
@@ -392,8 +392,8 @@ html.desktop-active .fsbl-linker[hover=true] {
 }
 
 .fsbl-tab-logo img {
-    height: 22px;
-    width: 22px;
+    height: 18px;
+    width: 18px;
 }
 
 .fsbl-tab .fsbl-tab-style {

--- a/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
@@ -12,7 +12,7 @@ let values = {
 	companionWindow: null,
 	moving: false
 };
-const COMPANION_EXPANDED_HEIGHT = 32;
+const COMPANION_EXPANDED_HEIGHT = 25;
 const COMPANION_CONTRACTED_HEIGHT = 10;
 const COMPANION_CONTRACTED_WIDTH = 86;
 let Logger = FSBL.Clients.Logger;


### PR DESCRIPTION
Kanban Ticket:  https://chartiq.kanbanize.com/ctrl_board/18/cards/7936/details

Reduced the titlebars from 32px to 25px and performed actions to make everything fit nicely. Tested with all the icons we use in Sales Demo and it should work fine. Let me know if there's any tweaks that need to be made.