### PR TITLE
8412 Fixes ability to rename Workspaces

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -185,7 +185,7 @@ export default class Workspaces extends React.Component {
 			return this.cancelEdit();
 		}
 
-		if (newName === oldName) return this.cancelEdit();
+		if (newName === oldName || newName.trim() === "") return this.cancelEdit();
 		let updatedWorkspaceList = this.state.workspaceList;
 		let index = updatedWorkspaceList.findIndex((el) => el.name === oldName);
 		//Set state locally so that the text doesn't change when the input field unmounts.


### PR DESCRIPTION
The workspace renaming dialog in user preferences will no longer allow an empty string to be entered