### PR TITLE
Make toolbar icon path relative

### DIFF
--- a/src-built-in/components/toolbar/config.json
+++ b/src-built-in/components/toolbar/config.json
@@ -2,7 +2,7 @@
     {
         "align": "left",
         "iconClasses": "finsemble-toolbar-brand-logo",
-        "icon": "/assets/img/Finsemble_Taskbar_Icon.png",
+        "icon": "../../assets/img/Finsemble_Taskbar_Icon.png",
         "menuType": "File Menu"
     },
     {


### PR DESCRIPTION
Make path to toolbar icon relative rather than absolute.