### PR TITLE
Better test for dev build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@
 		env.PORT = startupConfig[env.NODE_ENV].serverPort;
 	}
 
-	const isRunningDevTask = process.argv[2].startsWith("dev");
+	const isRunningDevTask = process.argv[2].startsWith("dev") || process.argv[2].endsWith("dev");
 
 	// #endregion
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,10 @@
 		env.PORT = startupConfig[env.NODE_ENV].serverPort;
 	}
 
-	const isRunningDevTask = process.argv[2].startsWith("dev") || process.argv[2].endsWith("dev");
+	// This variable controls whether the build should watch files for changes. This `startsWith` catches all of the 
+	// tasks that are dev * (dev, dev: fresh, dev: nolaunch), but excludes build:dev because it is intended to only
+	// build for a development environment and not watch for changes.
+	const isRunningDevTask = process.argv[2].startsWith("dev");
 
 	// #endregion
 


### PR DESCRIPTION
Minor change to ensure we detect dev builds via task names like build:dev in addition to dev:fresh and dev