### PR TITLE
adjusted CSS to deal with drag/scroll conflict.

### DIFF
--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -2,11 +2,16 @@
 @import url('./_themeWhitelabel.css');
 
 .fsbl-drag-handle {
-    position: absolute;
+    -webkit-app-region: drag;
     z-index: 2147483641;
-    top: 0px!important;
+    /* use below with window scrollbar hack */
+    position: fixed;
+    top: 5px!important;
+    margin-top: 0px!important;
+    /* use below without window scrollbar hack */
+    /* position: absolute; */
+    /* top: 0px!important; */
     /* background-color: red; */
-   -webkit-app-region: drag;
 }
 
 .fsbl-drag-handle.hidden {


### PR DESCRIPTION
Summary:
When a component is scrolled (vertically) the header stops working. The component cannot be dragged, docked, etc.

List branches or versions affected:

To Reproduce:
Make the welcome component short. Scroll. Try dragging.

Requirements:

Specification for fix:
This is caused by a conflict between the scrollbar hack (html.overflowY, body.overflowY) and the chromium hack. New CSS addresses this.