### PR TITLE
9180 Tab "Ghost Image" does not display the correct div

### DIFF
--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -47,6 +47,7 @@ html.desktop-active .fsbl-header {
 }
 
 .fsbl-header-title {
+    position: relative;
     height: 100%;
     overflow: hidden;
     align-items: center;


### PR DESCRIPTION
position:relative on fsbl-header-title fixes this.