### PR TITLE
Switched zoom from multiplication to addition

### DIFF
--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -18,13 +18,13 @@ function setZoom(pct) {
 
 // Zoom in. Zoom levels are saved as component state "fsbl-zoom"
 function zoomIn() {
-	window.fsblZoomLevel *= 1.1;
+	window.fsblZoomLevel += 0.1;
 	setZoom(window.fsblZoomLevel);
 	FSBL.Clients.WindowClient.setComponentState({ field: "fsbl-zoom", value: window.fsblZoomLevel });
 }
 
 function zoomOut() {
-	window.fsblZoomLevel *= .9;
+	window.fsblZoomLevel -= 0.1;
 	setZoom(window.fsblZoomLevel);
 	FSBL.Clients.WindowClient.setComponentState({ field: "fsbl-zoom", value: window.fsblZoomLevel });
 }


### PR DESCRIPTION
Zoom was being done using multiplication, but as a result, you could never get back to 100% using the zoom hotkeys. (1 * 1.1 * 0.9 = 0.99). Switching to addition means the zoom and be undone.