### PR TITLE
Insert drag handle inside of FSBLHeader rather than inside body.

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -194,13 +194,19 @@ class WindowTitleBar extends React.Component {
 	 * Hide the dragHandle during drop operations, so that it doesn't interfere
 	 */
 	resizeDragHandle() {
-		let dragHandle = document.querySelector(".fsbl-drag-handle");
+		const fsblHeader = document.querySelector(".fsbl-header");
+		if (!fsblHeader) {
+			// If there isn't an FSBLHeader then there doesn't need to be a drag handle.
+			return;
+		}
+
 		// Create the dragger if it doesn't already exist
+		let dragHandle = document.querySelector(".fsbl-drag-handle");
 		if (!dragHandle) {
 			dragHandle = document.createElement("div");
 			dragHandle.className = "fsbl-drag-handle";
 
-			document.body.insertBefore(dragHandle, document.body.firstChild);
+			fsblHeader.insertBefore(dragHandle, fsblHeader.firstChild);
 			var self = this;
 			window.addEventListener("resize", function () {
 				self.resizeDragHandle();
@@ -210,7 +216,7 @@ class WindowTitleBar extends React.Component {
 		// Set the height of the dragHandle to match the height of the window title bar
 		// Do this every time through the render loop just in case a customer builds a
 		// header bar with dynamic height!
-		let bounds = document.querySelector(".fsbl-header").getBoundingClientRect();
+		let bounds = fsblHeader.getBoundingClientRect();
 		dragHandle.style.height = (bounds.height - 5) + "px"; // Subtract 5 pixels from height in order to make room for resize window cursor at top edge of window
 		dragHandle.style.marginTop = (-bounds.height + 5) + "px"; // Negative margin pulls the drag handle up over the fixed header
 


### PR DESCRIPTION
A customer was having an issue with the window title bar buttons becoming unresponsive for certain zoom levels. When I investigated, I found that the drag handle was scaling. The drag handle was scaling because everything outside of FSBLHeader is scaled, and the drag handle was being inserted into the body tag. 

This PR inserts the drag handle inside of the header, with some minor refactoring.