### PR TITLE
9351 added hotkey config for central logger

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -27,6 +27,9 @@
 			"tiling": {
 				"enabled": true
 			}
+		},
+		"logger": {
+			"hotkeyShowCentralLogger": ["ctrl","`"]
 		}
 	},
 	"systemTrayIcon": "$applicationRoot/assets/img/Finsemble_Taskbar_Icon.png",


### PR DESCRIPTION
New config `finsemble.servicesConfig.logger.hotkeyShowCentralLogger` with a default of "ctrl","`". Requires updated Finsemble with matching PR.