### PR TITLE
9968 make the group icon work when a window has a parent

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -500,7 +500,6 @@ export default class TabRegion extends React.Component {
         }
 
         let tabRegionDropZoneStyle = { left: this.state.tabs.length * this.state.tabWidth + "px" }
-        console.log("TAB DROP REGION", tabRegionDropZoneStyle);
         let moveAreaClasses = "fsbl-tab-region-drag-area";
         if (this.isTabRegionOverflowing()) {
             moveAreaClasses += " gradient"

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -200,15 +200,15 @@ var Actions = {
 
 		Actions.getInitialTabList((err, values) => {
 			var onParentSet = () => {
-				Actions.parentWrapper = null;
-				Actions.getInitialTabList(() => {
-					FSBL.Clients.Logger.system.debug("docking group update after initial tab list");
-					onDockingGroupUpdate(null, {
-						data: {
-							groupData: windowTitleBarStore.getValue({ field: "Main.allDockingGroups" })
-						}
-					})
-				});
+					Actions.parentWrapper = null;
+					Actions.getInitialTabList(() => {
+						FSBL.Clients.Logger.system.debug("docking group update after initial tab list");
+						onDockingGroupUpdate(null, {
+							data: {
+								groupData: windowTitleBarStore.getValue({ field: "Main.allDockingGroups" })
+							}
+						})
+					});
 			};
 			var onParentCleared = () => {
 				Actions.parentWrapper = null;
@@ -240,6 +240,9 @@ var Actions = {
 	getMyDockingGroups: function (groupData) {
 		let myGroups = [];
 		let windowName = FSBL.Clients.WindowClient.getWindowNameForDocking();
+		if(FSBL.Clients.WindowClient.finsembleWindow.parentWindow){
+			windowName = FSBL.Clients.WindowClient.finsembleWindow.parentWindow.name
+		}
 		FSBL.Clients.Logger.system.debug("Getting docking groups for ", windowName, groupData);
 		if (groupData) {
 			for (var groupName in groupData) {

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -200,15 +200,15 @@ var Actions = {
 
 		Actions.getInitialTabList((err, values) => {
 			var onParentSet = () => {
-					Actions.parentWrapper = null;
-					Actions.getInitialTabList(() => {
-						FSBL.Clients.Logger.system.debug("docking group update after initial tab list");
-						onDockingGroupUpdate(null, {
-							data: {
-								groupData: windowTitleBarStore.getValue({ field: "Main.allDockingGroups" })
-							}
-						})
-					});
+				Actions.parentWrapper = null;
+				Actions.getInitialTabList(() => {
+					FSBL.Clients.Logger.system.debug("docking group update after initial tab list");
+					onDockingGroupUpdate(null, {
+						data: {
+							groupData: windowTitleBarStore.getValue({ field: "Main.allDockingGroups" })
+						}
+					})
+				});
 			};
 			var onParentCleared = () => {
 				Actions.parentWrapper = null;


### PR DESCRIPTION
When stacked windows are grouped their icon did not update.  We didn't check for parent and parent windows were't actually being set. To test create a stacked window, group it with some other window and restart. The group icon should come back in the correct state.

https://chartiq.kanbanize.com/ctrl_board/18/cards/9668/details

Also needs this: https://github.com/ChartIQ/finsemble/pull/902