### PR TITLE
[9791] fix sizing of toolbar pins with icons

### DIFF
--- a/assets/css/_toolbar.css
+++ b/assets/css/_toolbar.css
@@ -52,6 +52,7 @@
 .finsemble-toolbar-button {
     padding: 5px 6px;
     border: 1px solid var(--toolbar-background-color);
+    display: inline-flex;
 }
 
 .finsemble-toolbar-button-label {


### PR DESCRIPTION
**Resolves #9791**
- Set display: inline-flex on .finsemble-toolbar-button

**What to verify:**
- Check that toolbar pins with icons are displayed correctly