### PR TITLE
fix css issue with toolbar pins

### DIFF
--- a/assets/css/_toolbar.css
+++ b/assets/css/_toolbar.css
@@ -52,6 +52,7 @@
 .finsemble-toolbar-button {
     padding: 5px 6px;
     border: 1px solid var(--toolbar-background-color);
+    display: inline-flex;
 }
 
 .finsemble-toolbar-button-label {


### PR DESCRIPTION
**Resolves #9791**

- Added display:inline-flex to fix css issue with toolbar pins that had both icons and text

**What to verify:**
- Welcome Component pin shows both icon and text.
