### PR TITLE
9840 Move config to proper place, toolbar now rejects tiling requests.

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -506,11 +506,11 @@
 				"services": {
 					"dockingService": {
 						"isArrangable": false,
-						"ignoreSnappingRequests": true
+						"ignoreSnappingRequests": true,
+						"ignoreTilingAndTabbingRequests": true
 					},
 					"workspaceService": {
-						"global": true,
-						"ignoreTilingAndTabbingRequests": true
+						"global": true
 					}
 				},
 				"components": {


### PR DESCRIPTION
**Resolves #001**

- Fixes config to match what's looked at in docking.

**What to verify:**

- Try to tile onto the toolbar. You shouldn't be able to.