### PR TITLE
make sure titlebar doesnt get injected multiple times

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -422,6 +422,8 @@ class WindowTitleBar extends React.Component {
 
 if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
+	if (FSBL.titleBarInserted) return;
+	FSBL.titleBarInserted = true;
 	storeExports.initialize(function () {
 		HeaderActions = storeExports.Actions;
 		windowTitleBarStore = storeExports.getStore();


### PR DESCRIPTION
**Resolves Sales Demo Issue with Salesforce components**

- Prevent second call to injectHeader from breaking the titlebar