### PR TITLE
Companion window follows native window on maximize.

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
@@ -193,7 +193,6 @@ var Actions = {
 	onBoundsChanged(params) {
 		let bounds = params.data;
 		HeaderStore.setCompanionBounds(bounds);
-		if (HeaderStore.getMoving()) return;
 		if (HeaderStore.getState() === "small") {
 			let newBounds = Actions.getContractedBounds(bounds);
 			newBounds.persistBounds = false;
@@ -306,12 +305,6 @@ var Actions = {
 			//@note this was 500, it was lowered to 50 after improvements were made to the eventing system.
 		}, 50);
 
-	},
-	onCompanionMaximized() {
-		Logger.system.debug("Companion window maximized");
-		setTimeout(() => {
-			Actions.updateWindowPosition();
-		}, 500);
 	},
 	onCompanionMinimized() {
 		Logger.system.debug("Companion window minimized");

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -170,8 +170,8 @@ class _ToolbarStore {
 			}
 			done();
 		});
+
 		let onBoundsSet = (bounds) => {
-			debugger
 			bounds = bounds.data ? bounds.data : bounds;
 			self.Store.setValue({ field: "window-bounds", value: bounds });
 			FSBL.Clients.WindowClient.setComponentState({


### PR DESCRIPTION
**Resolves 9865**

- Removes unhelpful maximize handler. We used to not trigger bounds-changed events on maximize. Now we do. That code isn't necessary.
- Remove check for whether the window is moving. bounds-change-end doesn't happen if the window is moving.

**What to verify:**

- Maximize notepad. Verify position.
- Restore notepad. Verify position.
- Minimize notepad. Verify position.
- Restore notepad. Verify position.