### PR TITLE
[CS: 21] Adding config (already supported) to seed to turn on/off workspace autosave

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -34,6 +34,11 @@
 			"hotkeyShowCentralLogger": ["ctrl","shift","L"]
 		}
 	},
+	"preferences": {
+		"workspaceService": {
+			"promptUserOnDirtyWorkspace": true
+		}
+	},
 	"systemTrayIcon": "$applicationRoot/assets/img/Finsemble_Taskbar_Icon.png",
 	"systemTrayComponent": "File Menu",
 	"Window Manager": {

--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -36,7 +36,7 @@
 	},
 	"preferences": {
 		"workspaceService": {
-			"promptUserOnDirtyWorkspace": true
+			"promptUserOnDirtyWorkspace": false
 		}
 	},
 	"systemTrayIcon": "$applicationRoot/assets/img/Finsemble_Taskbar_Icon.png",


### PR DESCRIPTION
Set to true so that auto-save is disabled - switch it to false to reenable. Whatever our default this should probably be explicit in the config

**Resolves #CS:21**
https://chartiq.kanbanize.com/ctrl_board/21
- Add explicit config
- set to disable auto-save

**What to verify:**
- Open a workspace, change it, switch to another workspace and you should get prompted to save (rather than it auto-saving)