### PR TITLE
9876 double click toolbar

### DIFF
--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -171,7 +171,6 @@ class _ToolbarStore {
 			done();
 		});
 		let onBoundsSet = (bounds) => {
-			debugger
 			bounds = bounds.data ? bounds.data : bounds;
 			self.Store.setValue({ field: "window-bounds", value: bounds });
 			FSBL.Clients.WindowClient.setComponentState({
@@ -179,8 +178,13 @@ class _ToolbarStore {
 				value: bounds
 			}, Function.prototype);
 		}
-
-		FSBL.Clients.WindowClient.finsembleWindow.addListener("bounds-change-end", onBoundsSet)
+		let restoreWindow = (e) => {
+			e.cancel();
+			finsembleWindow.restore();
+		}
+		//Immediately restore on maximize.
+		finsembleWindow.addListener("maximized", restoreWindow);
+		finsembleWindow.addListener("bounds-change-end", onBoundsSet)
 
 		FSBL.Clients.HotkeyClient.addGlobalHotkey(["ctrl", "alt", "t"], () => {
 			self.showToolbarAtFront();

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -179,7 +179,6 @@ class _ToolbarStore {
 			}, Function.prototype);
 		}
 		let restoreWindow = (e) => {
-			e.cancel();
 			finsembleWindow.restore();
 		}
 		//Immediately restore on maximize.
@@ -193,15 +192,6 @@ class _ToolbarStore {
 		FSBL.Clients.HotkeyClient.addGlobalHotkey(["ctrl", "alt", "h"], () => {
 			self.hideToolbar();
 		});
-	}
-
-	/**
-	 * Function to handle maximize click
-	 * @memberof _ToolbarStore
-	 */
-	clickMaximize() {
-		var self = this;
-		FSBL.Clients.WindowClient.restore(Function.prototype);
 	}
 
 	/**
@@ -311,13 +301,10 @@ class _ToolbarStore {
 					self.retrieveSelfFromStorage(done);
 				},
 				function (done) {
-					FSBL.Clients.WindowClient.finWindow.addEventListener("maximized", function () {
-						self.clickMaximize();
-					});
-					FSBL.Clients.WindowClient.finWindow.addEventListener('focused', function () {
+					finsembleWindow.addEventListener('focused', function () {
 						self.onFocus();
 					});
-					FSBL.Clients.WindowClient.finWindow.addEventListener('blurred', function () {
+					finsembleWindow.addEventListener('blurred', function () {
 						self.onBlur();
 					});
 					done();


### PR DESCRIPTION
**Resolves 9876**

- On maximized, restore the window. This causes a flash, but doesn't allow the toolbar to take up all of your monitor's space.

**What to verify:**

- The toolbar doesn't maximize when double clicking the drag handle.

**Card**
https://chartiq.kanbanize.com/ctrl_board/18/cards/9876/details

**Finsemble PR**
https://github.com/ChartIQ/finsemble/pull/928