### PR TITLE
Fix drag handle width issues

### DIFF
--- a/src-built-in/components/common/windowTitle.jsx
+++ b/src-built-in/components/common/windowTitle.jsx
@@ -18,12 +18,19 @@ class title extends Component {
 	componentDidMount() {
 		this.getTitle();
 	}
+
+	//Triggers a re-rendering of the drag handle in the title bar.
+	componentDidUpdate() {
+		if (typeof this.props.onUpdate === "function") {
+			this.props.onUpdate();
+		}
+	}
+
 	componentWillMount() {
 		//todo
 		FSBL.FinsembleWindow.getInstance(this.props.windowIdentifier, (e, win) => {
 			win.addEventListener("title-changed", this.getTitle)
-		})
-
+		});
 	}
 	componentWillUnmount() {
 		//todo

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -66,6 +66,7 @@ export default class TabRegion extends React.Component {
         this.onTabListTranslateChanged = this.onTabListTranslateChanged.bind(this);
 
     }
+
     getTabWidth(params = {}) {
         let { boundingBox, tabList } = params;
         if (typeof (tabList) === "undefined") {
@@ -453,6 +454,7 @@ export default class TabRegion extends React.Component {
             translateX: value
         })
     }
+
     componentWillMount() {
         // Store.addListener({ field: "activeTab" }, this.onActiveTabChanged);
         Store.addListener({ field: "tabs" }, this.onTabsChanged);
@@ -544,7 +546,7 @@ function renderTitle() {
         className={"fsbl-header-title"}>
         <FinsembleHoverDetector edge="top" hoverAction={this.hoverAction.bind(this)} />
         <Logo windowIdentifier={FSBL.Clients.WindowClient.getWindowIdentifier()} />
-        <Title windowIdentifier={FSBL.Clients.WindowClient.getWindowIdentifier()}></Title>
+        <Title onUpdate={this.props.onTitleUpdated} windowIdentifier={FSBL.Clients.WindowClient.getWindowIdentifier()}></Title>
     </div>);
 }
 

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -88,6 +88,7 @@ class WindowTitleBar extends React.Component {
 		this.onHackScrollbarChanged = this.onHackScrollbarChanged.bind(this);
 		this.onTilingStop = this.onTilingStop.bind(this);
 		this.onTilingStart = this.onTilingStart.bind(this);
+		this.resizeDragHandle = this.resizeDragHandle.bind(this);
 
 	}
 	componentWillMount() {
@@ -399,6 +400,7 @@ class WindowTitleBar extends React.Component {
 							listenForDragOver={!this.state.allowDragOnCenterRegion}
 							tabs={this.state.tabs}
 							ref="tabArea"
+							onTitleUpdated={this.resizeDragHandle}
 						/>}
 
 				</div>


### PR DESCRIPTION
Top level component used to listen for title changes and then resize the drag handle. Now the component does it. To trigger the same result, we pass the resize drag handle down into the title component, and invoke it when the title changes. This allows the user to move the window properly.
