### PR TITLE
Set user preferences to always be on top

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -563,7 +563,8 @@
 				"height": 600,
 				"options": {
 					"autoShow": false,
-					"resizable": false
+					"resizable": false,
+					"alwaysOnTop": true
 				}
 			},
 			"component": {

--- a/src-built-in/components/userPreferences/src/app.jsx
+++ b/src-built-in/components/userPreferences/src/app.jsx
@@ -50,6 +50,7 @@ class UserPreferences extends React.Component {
 
 if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
+	FSBL.Clients.WindowClient.finsembleWindow.updateOptions({ alwaysOnTop: true });
 	FSBL.Clients.WindowClient.finsembleWindow.addEventListener("shown", () => {
 		finsembleWindow.bringToFront();
 		FSBL.Clients.DialogManager.showModal();

--- a/src-built-in/components/userPreferences/src/app.jsx
+++ b/src-built-in/components/userPreferences/src/app.jsx
@@ -50,7 +50,6 @@ class UserPreferences extends React.Component {
 
 if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
-	FSBL.Clients.WindowClient.finsembleWindow.updateOptions({ alwaysOnTop: true });
 	FSBL.Clients.WindowClient.finsembleWindow.addEventListener("shown", () => {
 		finsembleWindow.bringToFront();
 		FSBL.Clients.DialogManager.showModal();


### PR DESCRIPTION
**Resolves #10018**

- Makes User Preferences dialog always on top

**What to verify:**

1. Open User Preferences dialog
2. Click on scrim
3. User Preferences should remain above the scrim