### PR TITLE
Tie finsemble seed with a specific version of Finsemble Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@chartiq/finsemble": "latest",
+        "@chartiq/finsemble": "3.1.2",
         "@chartiq/finsemble-cli": "2.*",
         "@chartiq/finsemble-react-controls": "^3.1.2",
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@chartiq/finsemble": "3.1.2",
+        "@chartiq/finsemble": "3.2.*",
         "@chartiq/finsemble-cli": "2.*",
         "@chartiq/finsemble-react-controls": "^3.1.2",
         "async": "^2.6.0",


### PR DESCRIPTION
Finsemble seed should be tied to a specific version of Finsemble, rather than a name, so when you pull a tagged release, the version is correct.