### PR TITLE
8627 Example config prop for showing dev console on component launch

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -15,6 +15,7 @@
 			"component": {
 				"inject": false,
 				"spawnOnStartup": false,
+				"showDevConsoleOnVisible": true,
 				"preload": "$applicationRoot/preloads/zoom.js"
 			},
 			"foreign": {


### PR DESCRIPTION
**Resolves [8627](https://chartiq.kanbanize.com/ctrl_board/18/cards/8627/details)**

- Adds a config prop which will open dev console on component startup[

**What to verify:**

- If the 'showDevConsoleOnVisible' prop is true for a component's config, expect the dev console to launch alongside the component
