### PR TITLE
10200 ignore non-tab drops

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
+++ b/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
@@ -165,6 +165,7 @@ export default class TabRegion extends React.Component {
 
         FSBL.Clients.Logger.system.debug("Tab drag drop.");
         let identifier = this.extractWindowIdentifier(e);
+        if (!identifier) return; // the dropped item is not a tab
         FSBL.Clients.WindowClient.stopTilingOrTabbing({ allowDropOnSelf: true, action: "tabbing" }, () => {
             FSBL.Clients.RouterClient.transmit("tabbingDragEnd", { success: true });
             if (identifier && identifier.windowName) {

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -172,6 +172,7 @@ export default class TabRegion extends React.Component {
         e.stopPropagation();
         FSBL.Clients.Logger.system.debug("Tab drag drop.");
         let identifier = this.extractWindowIdentifier(e);
+        if (!identifier) return; // the dropped item is not a tab
         if (this.state.tabs.length === 1 && identifier.windowName === finsembleWindow.name) return FSBL.Clients.WindowClient.cancelTilingOrTabbing();
         FSBL.Clients.WindowClient.stopTilingOrTabbing({ allowDropOnSelf: true, action: "tabbing" }, () => {
             FSBL.Clients.RouterClient.transmit("tabbingDragEnd", { success: true });


### PR DESCRIPTION
**Resolves #10200**

- If no indentifier is present in the dropped data on a tab, ignore it

**What to verify:**

- Tabbing works as expected (including reordering, native tabs, switching)
- Dropping unexpected items (images, other random text onto tabs) doesnt cause errors. (there will still be the - extractWindowIdentifier error but no others)

** Notes **
The check for dropping on self is purposely missing in floatingTitlebar because the windowName and tab dont match and that check is not needed.
