### PR TITLE
9458 assimilation out of beta

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -16,6 +16,16 @@
 		"launcher": {
 			"staggerPixels": 40
 		},
+		"assimilation": {
+			"useOpenFinSpawn": false,
+			"enabled": true,
+			"blacklist": [],
+			"whitelist": [],
+			"onlySpawned": true,
+			"throttle": 10,
+			"focusDelay": 30,
+			"eventIgnore": 50
+		},
 		"docking": {
 			"enabled": true,
 			"groupTileBuffer": 30,
@@ -51,18 +61,7 @@
 		"showNativeTabs": true,
 		"floatingTitlebarComponent": "Floating Titlebar"
 	},
-	"betaFeatures": {
-		"assimilation": {
-			"useOpenFinSpawn": false,
-			"enabled": true,
-			"blacklist": [],
-			"whitelist": [],
-			"onlySpawned": true,
-			"throttle": 10,
-			"focusDelay": 30,
-			"eventIgnore": 50
-		}
-	},
+	"betaFeatures": {},
 	"splinteringConfig": {
 		"comment": "A SplinterAgent is just an openfin application that is capable of spawning specific components/services. If you try to spawn a component/service that one of these agents does not cover, it will be spawned by the defaultAgent. You can also specify maxWindowsPerAgent if you would like to limit your agents to some ceiling. This is useful when you have a particularly heavy component.",
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-			  "@chartiq/finsemble": "latest",
+        "@chartiq/finsemble": "latest",
         "@chartiq/finsemble-cli": "2.*",
         "@chartiq/finsemble-react-controls": "^3.1.2",
         "async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "author": "",
     "license": "ISC",
     "dependencies": {
-        "@chartiq/finsemble": "latest",
+			  "@chartiq/finsemble": "latest",
         "@chartiq/finsemble-cli": "2.*",
         "@chartiq/finsemble-react-controls": "^3.1.2",
         "async": "^2.6.0",


### PR DESCRIPTION
**Resolves [9458]()https://chartiq.kanbanize.com/ctrl_board/18/cards/9458/details**

- Moves assimilation config from `betaFeatures` to `servicesConfig`.

**What to verify:**

- Verify that all config was moved and that only that config was moved.