### PR TITLE
10271 no value should be undefined, rather than an empty object

### DIFF
--- a/src-built-in/adapters/indexedDBAdapter.js
+++ b/src-built-in/adapters/indexedDBAdapter.js
@@ -288,7 +288,8 @@ const IndexedDBAdapter = function () {
 		const request = objectStore.get(combinedKey);
 
 		request.onsuccess = (event) => {
-			const data = event.target.result && event.target.result.value ? event.target.result.value : undefined;
+			let data;
+			if(event.target.result) data = event.target.result.value;
 
 			Logger.system.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);
 			console.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);

--- a/src-built-in/adapters/indexedDBAdapter.js
+++ b/src-built-in/adapters/indexedDBAdapter.js
@@ -288,7 +288,7 @@ const IndexedDBAdapter = function () {
 		const request = objectStore.get(combinedKey);
 
 		request.onsuccess = (event) => {
-			const data = event.target.result && event.target.result.value ? event.target.result.value : {};
+			const data = event.target.result && event.target.result.value ? event.target.result.value : undefined;
 
 			Logger.system.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);
 			console.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);


### PR DESCRIPTION
**Resolves #10271**

- return undefined instead of {} when there isn't a value in the IndexedDB

**What to verify:**

Before https://github.com/ChartIQ/finsemble/pull/961

- Enable indexedDB adapter
- Create new workspace
- Try to switch workspaces (fails before this fix and the above PR)
