### PR TITLE
Companion window for tabbed apps disappear fix

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
@@ -257,7 +257,13 @@ var Actions = {
 
 		HeaderStore.setCompanionBounds(bounds);
 		if (!bounds.width) bounds.width = bounds.right - bounds.left;
-		FSBL.Clients.WindowClient.finsembleWindow.bringToFront();
+
+		Actions.isWindowVisible(function (err, isVisible) {
+			if (isVisible) {
+				FSBL.Clients.WindowClient.finsembleWindow.bringToFront();
+			}
+		});
+
 		let onBoundsSet = function (err) {
 			if (err) {
 				FSBL.Clients.Logger.error(err);
@@ -281,7 +287,6 @@ var Actions = {
 		FSBL.Clients.WindowClient.finsembleWindow.close({});
 	},
 	onCompanionHidden() {
-
 		Logger.system.debug("Companion window hidden");
 		FSBL.Clients.WindowClient.finsembleWindow.hide();
 	},


### PR DESCRIPTION
**Resolves #9652 #9646**

- bringToFront is not called for invisible window

**What to verify:**

- Open 2+ notepads
- Tab them together
- Move the active notepad a little bit many times to confirm the companion window doesn't disappear 
