### PR TITLE
 10375 check if name exists before using includes method

### DIFF
--- a/src-built-in/preloads/nativeOverrides.js
+++ b/src-built-in/preloads/nativeOverrides.js
@@ -27,7 +27,7 @@
 var originalWindowOpen = window.open;
 window.open = function (URL, name, specs, replace) {
 	// For some strange reason, openfin notifications use window.open. So we make an exception for that one case.
-	if (name.indexOf("openfin-child-window") != -1) {
+	if (name && name.includes("openfin-child-window")) {
 		originalWindowOpen.call(window, URL, name, specs, replace);
 		return;
 	}


### PR DESCRIPTION
**Resolves #10375**

- Check if name exists before calling a method on it.

**What to verify:**

- Verify that window open doesn't throw a reference of undefined error when calling `window.open("http://www.google.com")`

There is an error from the launcher that will need to be addressed in another PR.
