### PR TITLE
[AppLauncher] Fixes for folder rename, tags list, favorite icon

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -45,6 +45,8 @@
 									}
 								},
 								"Favorites": {
+									"icon": "ff-favorite",
+									"type": "folder",
 									"disableUserRemove": true,
 									"apps" : {}
 								}

--- a/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
@@ -21,7 +21,8 @@ export default class FoldersList extends React.Component {
 		this.changeFolderName = this.changeFolderName.bind(this)
 		this.onFoldersListUpdate = this.onFoldersListUpdate.bind(this)
 		this.keyPressed = this.keyPressed.bind(this)
-		this.deleteFolder = this.deleteFolder.bind(this);
+		this.deleteFolder = this.deleteFolder.bind(this)
+		this.onFocusRemove = this.onFocusRemove.bind(this)
 	}
 
 	onAppDrop(event, folder) {
@@ -52,6 +53,26 @@ export default class FoldersList extends React.Component {
 		})
 	}
 
+	onFocusRemove(event) {
+		// We don't want to hide the input if user clicked on it
+		// We only hide when the click is anywhere else in the document
+		if(event.target.id === 'rename') {
+			return
+		}
+		// If focus removed and nothing was type, then just hide
+		// and consider it a rename cancel
+		if(!this.state.folderNameInput) {
+			// Cancel rename
+			this.setState({
+				renamingFolder: null
+			})
+			this.removeClickListener()
+			return
+		}
+		//Finally, all good and so we can rename the folder
+		this.attempRename()
+	}
+
 	componentWillMount() {
 		getStore().addListener({ field: 'appFolders.list' }, this.onFoldersListUpdate)
 	}
@@ -65,7 +86,8 @@ export default class FoldersList extends React.Component {
 		e.stopPropagation();
 		this.setState({
 			renamingFolder: name
-		});
+		})
+		this.addClickListener()
 	}
 
 	changeFolderName(e) {
@@ -77,40 +99,57 @@ export default class FoldersList extends React.Component {
 	deleteFolder(name, e) {
 		e.stopPropagation();
 		e.preventDefault();
-		storeActions.deleteFolder(name);
+		// Do not attemp to delete if user is renaming a folder
+		!this.state.renamingFolder && storeActions.deleteFolder(name)
 	}
 
 	keyPressed(e) {
 		if (e.key === "Enter") {
-			const input = this.state.folderNameInput.trim()
-			const oldName = this.state.renamingFolder, newName = input
-			// Check user input to make sure its at least 1 character
-			// made of string, number or both
-			if (!/^([a-zA-Z0-9\s]{1,})$/.test(input)) {
-				// Do not rename
-				console.warn('A valid folder name is required. /^([a-zA-Z0-9\s]{1,})$/')
-				return
-			}
-			this.setState({
-				folderNameInput: "",
-				renamingFolder: null
-			}, () => {
-				storeActions.renameFolder(oldName, newName);
-			});
+			this.attempRename()
 		}
+	}
+
+	addClickListener() {
+		document.addEventListener('click', this.onFocusRemove)
+	}
+
+	removeClickListener() {
+		document.removeEventListener('click', this.onFocusRemove)
+	}
+	/**
+	 * To be called when user press Enter or when focus is removed
+	 */
+	attempRename() {
+		const input = this.state.folderNameInput.trim()
+		const oldName = this.state.renamingFolder, newName = input
+		// Check user input to make sure its at least 1 character
+		// made of string, number or both
+		if (!/^([a-zA-Z0-9\s]{1,})$/.test(input)) {
+			// Do not rename
+			console.warn('A valid folder name is required. /^([a-zA-Z0-9\s]{1,})$/')
+			return
+		}
+		this.setState({
+			folderNameInput: "",
+			renamingFolder: null
+		}, () => {
+			storeActions.renameFolder(oldName, newName)
+			// No need for the click listener any more
+			this.removeClickListener()
+		})
 	}
 
 	renderFoldersList() {
 		const folders = storeActions.getFolders()
 		return this.state.foldersList.map((folderName, index) => {
-			const folder = folders[folderName];
+			const folder = folders[folderName]
 			let className = 'complex-menu-section-toggle'
 			if (this.state.activeFolder === folderName) {
 				className += ' active-section-toggle'
 			}
 
 			let nameField = folder.icon === 'ff-folder' && this.state.renamingFolder === folderName ?
-				<input value={this.state.folderNameInput}
+				<input id="rename" value={this.state.folderNameInput}
 					onChange={this.changeFolderName}
 					onKeyPress={this.keyPressed} autoFocus /> : folderName
 

--- a/src-built-in/components/appLauncher2/src/components/TagsList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/TagsList.jsx
@@ -10,7 +10,7 @@ export default class TagsList extends React.Component {
 	constructor(props) {
 		super(props)
 		this.state = {
-			tags: []
+			tags: storeActions.getTags()
 		}
 		this.onTagDelete = this.onTagDelete.bind(this);
 		this.onTagListUpdate = this.onTagListUpdate.bind(this);

--- a/src-built-in/components/appLauncher2/src/stores/StoreActions.js
+++ b/src-built-in/components/appLauncher2/src/stores/StoreActions.js
@@ -94,7 +94,7 @@ function reorderFolders(destIndex, srcIndex) {
 
 function addNewFolder(name) {
 	// Find folders that have a name of "New folder" or "New folder #"
-	const newFolders = Object.keys(data.folders).filter((folder) => {
+	const newFolders = data.foldersList.filter((folder) => {
 		return folder.toLowerCase().indexOf('new folder') > -1
 	})
 	const folderName = name || `New folder ${newFolders.length + 1}`
@@ -116,6 +116,7 @@ function deleteFolder(folderName) {
 	// Check if user is trying to delete the active folder
 	if(folderName === data.activeFolder) {
 		data.activeFolder = MY_APPS
+		_setValue('activeFolder', data.activeFolder)
 	}
 
 	delete data.folders[folderName] && _setFolders(() => {
@@ -127,15 +128,15 @@ function deleteFolder(folderName) {
 }
 
 function renameFolder(oldName, newName) {
-	let oldFolder = data.folders[oldName];
-	data.folders[newName] = oldFolder;
-	delete data.folders[oldName];
+	let oldFolder = data.folders[oldName]
+	data.folders[newName] = oldFolder
 	_setFolders(() => {
 		let indexOfOld = data.foldersList.findIndex((folderName) => {
-			return folderName === oldName;
-		});
-		data.foldersList[indexOfOld] = newName;
-		_setValue('appFolders.list', data.foldersList);
+			return folderName === oldName
+		})
+		data.foldersList[indexOfOld] = newName
+		_setValue('appFolders.list', data.foldersList)
+		delete data.folders[oldName]
 	});
 }
 


### PR DESCRIPTION
**Resolves issues**

Ticket [10441](https://chartiq.kanbanize.com/ctrl_board/18/cards/10441/details)
Ticket [10443](https://chartiq.kanbanize.com/ctrl_board/18/cards/10443/details)
Ticket [10389](https://chartiq.kanbanize.com/ctrl_board/18/cards/10389/details)
Ticket [10388](https://chartiq.kanbanize.com/ctrl_board/18/cards/10388/details)

**Description of change**
- Cancel folder rename on focus remove when no input given
- Save folder name when user click anywhere except rename input
- Restore favorite folder icon
- Persist filter tags list on Finsemble restart

**Description of testing**
Pull the branch 

> 10442_10443_10389_10388_fixes

, check out and make sure that the above list items are either fixed/enhanced.

