### PR TITLE
Fixes tags menu visually indicate what tags are active

### DIFF
--- a/assets/css/_theme.css
+++ b/assets/css/_theme.css
@@ -250,6 +250,7 @@
     --tag-font-color: var(--primary-font-color);
     --tag-font-weight: var(--primary-font-weight);
     --tag-close-icon-hover-color: var(--secondary-negative-color);
+    --tag-checkmark-icon-color: var(--green);
 
 
     /* App Menu */

--- a/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
+++ b/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
@@ -67,10 +67,16 @@ class SearchBar extends Component {
 	 * @param {string} tag The name of the tag
 	 */
 	selectTag(tag) {
+		let tags = storeActions.getActiveTags();
+
 		this.setState({
 			tagSelectorOpen: false
 		}, () => {
-			storeActions.addTag(tag);
+			if (tags.includes(tag)) {
+				storeActions.removeTag(tag);
+			} else {
+				storeActions.addTag(tag);
+			}
 		});
 	}
 	/**
@@ -95,6 +101,8 @@ class SearchBar extends Component {
 			tagListClass += " hidden";
 		}
 
+		let activeTags = storeActions.getActiveTags();
+
 		return (
 			<div className='search-main'>
 				<Toast installationActionTaken={this.props.installationActionTaken} />
@@ -108,7 +116,7 @@ class SearchBar extends Component {
 						<i className='ff-search'></i>
 						<input className='search-input' type="text" value={this.state.searchValue} onChange={this.changeSearch} />
 					</div>
-					<TagsMenu list={this.props.tags} onItemClick={this.selectTag} label={"Tags"} align='right' />
+					<TagsMenu active={activeTags} list={this.props.tags} onItemClick={this.selectTag} label={"Tags"} align='right' />
 				</div>
 				<div className='label-bar'>
 					{this.props.activeTags.map((tag, i) => {

--- a/src-built-in/components/appLauncher2/src/components/FilterSort.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FilterSort.jsx
@@ -1,6 +1,5 @@
 import React from  'react'
 import SearchBox from './SearchBox'
-// import TagsMenu from './TagsMenu'
 import TagsMenu from '../../../shared/TagsMenu';
 import SortBy from './SortBy'
 import TagsList from './TagsList'
@@ -40,14 +39,23 @@ export default class FilterSort extends React.Component {
 	* so that other components get notified
 	**/
 	onTagClick(tag) {
-		storeActions.addTag(tag)
+		console.log('tag: ', tag);
+		let tags = storeActions.getTags();
+
+		console.log('tags: ', tags);
+		if (tags.includes(tag)) {
+			storeActions.deleteTag(tag);
+		} else {
+			storeActions.addTag(tag)
+		}
 	}
 
 	componentDidMount(){
 		this.setStateValues()
 	}
-	
+
 	render() {
+		let activeTags = storeActions.getTags();
 		return (
 			<div className="filter-sort">
 				<SearchBox />
@@ -57,6 +65,7 @@ export default class FilterSort extends React.Component {
 					label="Tags"
 					align="right"
 					list={this.state.tags}
+					active={activeTags}
 					onItemClick={this.onTagClick}/>
 			</div>
 			)

--- a/src-built-in/components/appLauncher2/src/components/FilterSort.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FilterSort.jsx
@@ -39,10 +39,8 @@ export default class FilterSort extends React.Component {
 	* so that other components get notified
 	**/
 	onTagClick(tag) {
-		console.log('tag: ', tag);
 		let tags = storeActions.getTags();
 
-		console.log('tags: ', tags);
 		if (tags.includes(tag)) {
 			storeActions.deleteTag(tag);
 		} else {

--- a/src-built-in/components/shared/TagsMenu.jsx
+++ b/src-built-in/components/shared/TagsMenu.jsx
@@ -73,7 +73,7 @@ export default class TagsMenu extends React.Component {
 
 						return <li key={index}
 							onClick={() => this.onItemClick(item)}>
-							{active && <i className='ff-check-mark' />}&nbsp;&nbsp;{item}
+							{active ? <i className='ff-check-mark' /> : <div className='tags-checkmark-wrapper'>&nbsp;</div>}&nbsp;&nbsp;{item}
 						</li>
 					})
 				} </ul>

--- a/src-built-in/components/shared/TagsMenu.jsx
+++ b/src-built-in/components/shared/TagsMenu.jsx
@@ -68,9 +68,12 @@ export default class TagsMenu extends React.Component {
 			<div className="tags-menu" style={styles}>
 				<ul> {
 					items.map((item, index) => {
+						let active = this.props.active.includes(item);
+
+
 						return <li key={index}
 							onClick={() => this.onItemClick(item)}>
-							{item}
+							{active && <i className='ff-check-mark' />}&nbsp;&nbsp;{item}
 						</li>
 					})
 				} </ul>

--- a/src-built-in/components/shared/style.css
+++ b/src-built-in/components/shared/style.css
@@ -25,12 +25,12 @@
 	z-index: 11;
     top: 22px;
 	position: absolute;
-	width: 100px;
+	width: 130px;
 	max-height: 200px;
 	overflow-y: auto;
 	border-radius: 3px;
   	background-color: var(--tag-background-color);
-	padding: 5px 10px;
+	padding: 5px 0px;
 }
 .tags-menu ul {
 	padding: 0;
@@ -42,6 +42,7 @@
 	font-size: 11px;
 	list-style: none;
 	color: var(--tag-font-color);
+	padding: 0 10px;
 }
 
 .app-tag {

--- a/src-built-in/components/shared/style.css
+++ b/src-built-in/components/shared/style.css
@@ -45,6 +45,10 @@
 	padding: 0 10px;
 }
 
+.tags-checkmark-wrapper {
+	width: 10px;
+}
+
 .app-tag {
 	height: 17px;
 	border-radius: 2px;

--- a/src-built-in/components/shared/style.css
+++ b/src-built-in/components/shared/style.css
@@ -43,6 +43,12 @@
 	list-style: none;
 	color: var(--tag-font-color);
 	padding: 0 10px;
+	display: flex;
+	align-items: center;
+}
+
+.tags-menu .ff-check-mark {
+	color: var(--tag-checkmark-icon-color);
 }
 
 .tags-checkmark-wrapper {


### PR DESCRIPTION
**Resolves issue [10445](https://chartiq.kanbanize.com/ctrl_board/18/cards/10445/details)**

**Description of change**
- Added font icon to tags menu for app catalog and new app launcher that will indicate when a tag is active or not
- Instead of the tags menu simply adding tags, it can now toggle tags. If its already applied and is clicked it will be removed and vice versa

**Description of testing**
- Verify that you can add a tag in app catalog and app launcher 2. When the tag is added, a check mark is added next to the tag that means its enabled. Clicking any tags with check marks next to them will also remove that tag.
