### PR TITLE
[App Catalog] Fix Carousels with <> 4 cards. Handle  app results when cards on a pa…

### DIFF
--- a/src-built-in/components/appCatalog2/src/components/AppResults.jsx
+++ b/src-built-in/components/appCatalog2/src/components/AppResults.jsx
@@ -55,11 +55,6 @@ const AppResults = props => {
 			let card = cardsForShowcase[i];
 			let name = card.title || card.name;
 
-			if (cardsInRow.length === 4) {
-				cardRows.push(cardsInRow);
-				cardsInRow = [];
-			}
-
 			let key = "card-" + i + "-" + name.toLowerCase();
 
 			cardsInRow.push(
@@ -67,9 +62,11 @@ const AppResults = props => {
 					<AppCard {...card} viewAppShowcase={props.viewAppShowcase} />
 				</td>
 			);
-		}
-		if (cardRows.length === 0) {
-			cardRows.push(cardsInRow);
+
+			if (cardsInRow.length === 4 || i === cardsForShowcase.length - 1) {
+				cardRows.push(cardsInRow);
+				cardsInRow = [];
+			}
 		}
 
 		return cardRows;

--- a/src-built-in/components/appCatalog2/src/components/Carousel.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Carousel.jsx
@@ -111,12 +111,12 @@ export default class Carousel extends Component {
 		let chevron_left_style = 'ff-chevron-left', chevron_right_style = 'ff-chevron-right';
 		let left_click = this.pageDown, right_click = this.pageUp;
 
-		if (this.state.firstIndex + 3 > this.props.cards.length - 1) {
+		if (this.state.firstIndex + 3 >= this.props.cards.length - 1) {
 			chevron_right_style += " disabled";
 			right_click = Function.prototype;
 		}
 
-		if (this.state.firstIndex <= 4) {
+		if (this.state.firstIndex === 0) {
 			chevron_left_style += " disabled";
 			left_click = Function.prototype;
 		}

--- a/src-built-in/components/appCatalog2/src/components/Carousel.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Carousel.jsx
@@ -83,7 +83,7 @@ export default class Carousel extends Component {
 	 * Spits out a warning if the number of cards supplied to the carousel is < 4
 	 */
 	notEnoughCards() {
-		console.log('Less than 4 card supplied. This carousel will not display optimally');
+		console.warn('Less than 4 card supplied. This carousel will not display optimally');
 	}
 	/**
 	 * Function to build the items in the carousel

--- a/src-built-in/components/appCatalog2/src/components/Home.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Home.jsx
@@ -25,7 +25,7 @@ const Home = props => {
 	});
 
 	let carousel2 = props.cards.filter((card) => {
-		return card.tags.includes("newrelease");
+		return card.tags.includes("app");
 	});
 
 	return (

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -124,7 +124,7 @@ export default class Search extends React.Component {
 		storeExports.Actions.setFocus(true, e.target)
 
 		setTimeout(function () {
-			
+
 			// select the old search text, so the user can edit it or type over it
 			// Do this in a timeout to give some time for the animation to work
 			var element = document.getElementById("searchInput");


### PR DESCRIPTION
**Resolves issue [10447](https://chartiq.kanbanize.com/ctrl_board/18/cards/10447/details)**

**Description of change**
- Adjusts carousels to allow for (and console warn) a user that a carousel should have at least 4 cards for optimal displaying
- Adjusts AppResults page when filtering by tags to all for rows of less than 4 for when filtered results are not divisible by 4.

**Description of testing**
- (Requires a specific branch of fdc-appd) Upon opening the app one carousel should seem off as it only has 2 cards, the other will have 5 cards and allow for previewing the disabled left and right arrows when the end of a list is reached.
