### PR TITLE
[AppLauncher] Reordering folders, unique new folders name...

### DIFF
--- a/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
@@ -120,6 +120,7 @@ export default class FoldersList extends React.Component {
 	 * To be called when user press Enter or when focus is removed
 	 */
 	attempRename() {
+		const folders = storeActions.getFolders()
 		const input = this.state.folderNameInput.trim()
 		const oldName = this.state.renamingFolder, newName = input
 		// Check user input to make sure its at least 1 character
@@ -129,6 +130,12 @@ export default class FoldersList extends React.Component {
 			console.warn('A valid folder name is required. /^([a-zA-Z0-9\s]{1,})$/')
 			return
 		}
+		// Names must be unique, folders cant share same names
+		if (folders[newName]) {
+			console.log('Folder name ', newName, 'already exists.')
+			return
+		}
+
 		this.setState({
 			folderNameInput: "",
 			renamingFolder: null

--- a/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
@@ -133,9 +133,20 @@ export default class FoldersList extends React.Component {
 		}
 		// Names must be unique, folders cant share same names
 		if (folders[newName]) {
-			console.log('Folder name ', newName, 'already exists.')
 			return this.setState({
 				isNameError: true
+			}, () => {
+				let proceed = window.confirm("Folder name already exists. A (1) will be appended.");
+				if (proceed) {
+					this.setState({
+						folderNameInput: "",
+						renamingFolder: null,
+						isNameError: false
+					}, () => {
+						storeActions.renameFolder(oldName, newName + "(1)");
+						this.removeClickListener();
+					})
+				}
 			});
 		}
 

--- a/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
@@ -15,7 +15,8 @@ export default class FoldersList extends React.Component {
 			foldersList: storeActions.getFoldersList(),
 			activeFolder: storeActions.getActiveFolderName(),
 			renamingFolder: null,
-			folderNameInput: ''
+			folderNameInput: '',
+			isNameError: false
 		}
 		this.renameFolder = this.renameFolder.bind(this)
 		this.changeFolderName = this.changeFolderName.bind(this)
@@ -133,12 +134,15 @@ export default class FoldersList extends React.Component {
 		// Names must be unique, folders cant share same names
 		if (folders[newName]) {
 			console.log('Folder name ', newName, 'already exists.')
-			return
+			return this.setState({
+				isNameError: true
+			});
 		}
 
 		this.setState({
 			folderNameInput: "",
-			renamingFolder: null
+			renamingFolder: null,
+			isNameError: false
 		}, () => {
 			storeActions.renameFolder(oldName, newName)
 			// No need for the click listener any more
@@ -156,9 +160,9 @@ export default class FoldersList extends React.Component {
 			}
 
 			let nameField = folder.icon === 'ff-folder' && this.state.renamingFolder === folderName ?
-				<input id="rename" value={this.state.folderNameInput}
+				<input id="rename" className={this.state.isNameError ? 'error' : ''} value={this.state.folderNameInput}
 					onChange={this.changeFolderName}
-					onKeyPress={this.keyPressed} autoFocus /> : folderName
+					onKeyPress={this.keyPressed} autoFocus tooltip={this.state.isNameError ? "Names must be unique" : ""} /> : folderName
 
 			return <FinsembleDraggable
 				draggableId={folderName}

--- a/src-built-in/components/appLauncher2/src/stores/StoreActions.js
+++ b/src-built-in/components/appLauncher2/src/stores/StoreActions.js
@@ -86,18 +86,28 @@ function getSingleFolder(folderName) {
 }
 
 function reorderFolders(destIndex, srcIndex) {
-	const dest = data.foldersList[destIndex]
-	data.foldersList[destIndex] = data.foldersList[srcIndex]
-	data.foldersList[srcIndex] = dest
+	const movedFolder = data.foldersList[destIndex]
+    const remainingItems = data.foldersList.filter((item, index) => index !== destIndex)
+    data.foldersList = [
+        ...remainingItems.slice(0, srcIndex),
+        movedFolder,
+        ...remainingItems.slice(srcIndex)
+    ]
 	_setValue('appFolders.list', data.foldersList)
+	return data.foldersList
 }
 
 function addNewFolder(name) {
+	// Each new folder is given a number, lets store them here
+	// to get the highest one and then increment
+	const newFoldersNums = [0]
 	// Find folders that have a name of "New folder" or "New folder #"
-	const newFolders = Object.keys(data.folders).filter((folder) => {
-		return folder.toLowerCase().indexOf('new folder') > -1
+	data.foldersList.forEach((folder) => {
+		const numbers = folder.match(/\d+/g) || []
+		newFoldersNums.push( Math.max.apply(this, numbers) )
 	})
-	const folderName = name || `New folder ${newFolders.length + 1}`
+	const highestFolderNumber = Math.max.apply(this, newFoldersNums)
+	const folderName = name || `New folder ${highestFolderNumber + 1}`
 	const newFolder = {
 		disableUserRemove: true,
 		icon: "ff-folder",

--- a/src-built-in/components/appLauncher2/style.css
+++ b/src-built-in/components/appLauncher2/style.css
@@ -37,7 +37,8 @@ img {
 .folder-list {
     margin-top: 10px;
     max-height: 245px;
-    overflow: auto;
+    overflow-y: auto;
+    overflow-x: hidden;
 }
 .bottom {
     position: absolute;

--- a/src-built-in/components/appLauncher2/style.css
+++ b/src-built-in/components/appLauncher2/style.css
@@ -51,6 +51,10 @@ img {
     justify-content: flex-start;
 }
 
+.complex-menu-section-toggle #rename.error {
+    border-bottom: 1px solid var(--red3);
+}
+
 .complex-menu-wrapper {
     display: flex;
     height: 100%;


### PR DESCRIPTION
**Resolves issues **
[10385](https://chartiq.kanbanize.com/ctrl_board/18/cards/10385/details)
[10462](https://chartiq.kanbanize.com/ctrl_board/18/cards/10462/details)
[10460](https://chartiq.kanbanize.com/ctrl_board/18/cards/10460/details)

**Description of change**
- Disallow a folder name that already exist.
- Fix reordering so that it works even when moving item few indexes
- When adding a new folder, makes sure the new name is always unique 

**Description of testing**
Confirm that the above 3 fixes are working as expected
