### PR TITLE
[AppLauncher] Launch apps with single click, tag filter using AND instead or OR

### DIFF
--- a/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
@@ -33,7 +33,11 @@ export default class AppActionsMenu extends React.Component {
 		document.removeEventListener('mousedown', this.handleClickOutside);
 	}
 
-	toggleMenu() {
+	toggleMenu(e) {
+		if (e) {
+			e.stopPropagation();
+			e.preventDefault();
+		}
 		this.setState({
 			isVisible: !this.state.isVisible
 		})

--- a/src-built-in/components/appLauncher2/src/components/AppDefinition.jsx
+++ b/src-built-in/components/appLauncher2/src/components/AppDefinition.jsx
@@ -18,7 +18,7 @@ export default class AppDefinition extends React.Component {
 			favorites: []
 		}
 		this.onDragToFolder = this.onDragToFolder.bind(this)
-		this.onDoubleClick = this.onDoubleClick.bind(this)
+		this.onItemClick = this.onItemClick.bind(this);
 	}
 
 	/**
@@ -28,15 +28,18 @@ export default class AppDefinition extends React.Component {
 		event.dataTransfer
 			.setData('app', JSON.stringify(this.props.app))
 	}
+
 	/**
-	 * Spawn a component on double click
+	 * Spawns a component on click
+	 * @param {object} e The Synthetic React event
 	 */
-	onDoubleClick(app) {
-		if (pendingSpawn) return
-		pendingSpawn = true
-		FSBL.Clients.LauncherClient.spawn(app.name, {}, (error, data) => {
-			pendingSpawn = false
-		})
+	onItemClick() {
+		if (pendingSpawn) return;
+		pendingSpawn = true;
+		let name = this.props.app.title || this.props.app.name;
+		FSBL.Clients.LauncherClient.spawn(name, {}, (err, data) => {
+			pendingSpawn = false;
+		});
 	}
 
 	isFavorite() {
@@ -47,7 +50,7 @@ export default class AppDefinition extends React.Component {
 	render() {
 		const app = this.props.app
 		return (
-			<div onDoubleClick={() => this.onDoubleClick(app)} className="app-item" draggable="true" onDragStart={this.onDragToFolder}>
+			<div onClick={this.onItemClick} className="app-item" draggable="true" onDragStart={this.onDragToFolder}>
 				<span className="app-item-title">
 					{app.icon !== undefined ? <i className={app.icon}></i> : null}
 					{app.name} {this.isFavorite() && <i className='ff-favorite'></i>}

--- a/src-built-in/components/appLauncher2/src/components/AppTagsList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/AppTagsList.jsx
@@ -12,6 +12,7 @@ export default class AppTagsList extends React.Component {
         this.highlightTag = this.highlightTag.bind(this);
         this.clearHighlights = this.clearHighlights.bind(this);
         this.generateTags = this.generateTags.bind(this);
+        this.onTagClick = this.onTagClick.bind(this);
     }
 
     highlightTag(index) {
@@ -26,13 +27,21 @@ export default class AppTagsList extends React.Component {
         });
     }
 
+    onTagClick(tag, e) {
+        if (e) {
+            e.stopPropagation();
+            e.preventDefault();
+        }
+        storeActions.addTag(tag);
+    }
+
     generateTags() {
         let { highlightedTag:highlight } = this.state;
 
         let tags = this.props.tags.map((tag, i) => {
             let style = highlight === i ? "tag-name highlight" : "tag-name";
             return (
-                <span key={i} className={style} onClick={storeActions.addTag.bind(this, tag)} onMouseEnter={this.highlightTag.bind(this, i)} onMouseLeave={this.clearHighlights}>
+                <span key={i} className={style} onClick={this.onTagClick.bind(this, tag)} onMouseEnter={this.highlightTag.bind(this, i)} onMouseLeave={this.clearHighlights}>
                     {this.props.tags[i + 1] ? `${tag}, ` : `${tag}`}
                 </span>
             );

--- a/src-built-in/components/appLauncher2/src/components/Content.jsx
+++ b/src-built-in/components/appLauncher2/src/components/Content.jsx
@@ -51,11 +51,14 @@ export default class Content extends React.Component {
 		if (!this.state.tags) {
 			return apps
 		}
+		//All active tags must be present in an app for it to show
 		return apps.filter((app) => {
-			const regex = new RegExp(this.state.tags.join('|'))
-			const result = app.tags.join(' ').match(regex)
-			return result
-		})
+			for (let i = 0; i < this.state.tags.length; i++) {
+				let tag = this.state.tags[i];
+				if (!app.tags.includes(tag)) return false
+			}
+			return true;
+		});
 	}
 
 	onActiveFolderChanged(error, data) {


### PR DESCRIPTION
**Resolves issues**
[10405](https://chartiq.kanbanize.com/ctrl_board/18/cards/10383/subtasks)
[10436](https://chartiq.kanbanize.com/ctrl_board/18/cards/10383/subtasks)

**Description of change**
- Apps now launch from a single click on the appLauncher (will not launch apps when the context menu or tags are clicked)
- Tag search is now AND not OR. Only apps containing _all_ currently filtered tags will show

**Description of testing**
- Confirm that multiple active tags only shows apps that contain all those tags, and that a single click will launch an app
