### PR TITLE
Fixe oozing button in tutorial accountList.css

### DIFF
--- a/tutorials/accountList/accountList.css
+++ b/tutorials/accountList/accountList.css
@@ -38,10 +38,11 @@ customer.selected {
 relocate {
 	display: block;
 	position: fixed;
-	bottom: 0px;
+	bottom: 25px;
 	text-align: center;
 	background-color: #eee;
 	cursor: pointer;
+	height: 34px;
 	margin: 20px;
 	padding: 10px;
 	background-color: #068de6;


### PR DESCRIPTION
**Resolves issue [10486](https://chartiq.kanbanize.com/ctrl_board/18/cards/10486/details)**

**Description of change**
- Added explicit `height` prop to the `relocate` component in `accountList.css` to prevent it from changing height.
- Also bumped `bottom: 0px` to `bottom: 25px` to prevent it from showing up beyond the border of the window on launch.

**Description of testing**
- Check that the `accountList` component looks ok both at launch and on resize.
