### PR TITLE
[App Catalog] 10447 disable tabbing and visuals

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -478,6 +478,9 @@ export default class TabRegion extends React.Component {
 
     }
     hoverAction(newHoverState) {
+        if (FSBL.Clients.WindowClient.shouldIgnoreTabbingRequests()) {
+            return;
+        }
         this.setState({ hoverState: newHoverState });
     }
 


### PR DESCRIPTION
**Resolves issue [10449](https://chartiq.kanbanize.com/ctrl_board/18/cards/10447/subtasks)**

**Description of change**
-Calls the window client to see if a titlebar should ignore tabbing. If it returns true the hover state won't be toggled which will prevent tabbing visuals from showing.

**Description of testing**
- When hovering over the AppCatalog title, if the component is set to ignoreTabbingRequests (like the App Catalog) then the tab should not change appearence.
