### PR TITLE
[App Catalog] 10447 disable tabbing and visuals

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -722,7 +722,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangeable": false,
+						"isArrangable": false,
 						"ignoreTilingAndTabbingRequests": true,
 						"ignoreSnappingRequests": true
 					}
@@ -736,6 +736,7 @@
 							"hideMaximize": true
 						},
 						"persistWindowState": true,
+						"showTabs": false,
 						"title": "App Catalog"
 					}
 				}

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -478,6 +478,9 @@ export default class TabRegion extends React.Component {
 
     }
     hoverAction(newHoverState) {
+        if (FSBL.Clients.WindowClient.shouldIgnoreTabbingRequests()) {
+            return;
+        }
         this.setState({ hoverState: newHoverState });
     }
 

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -478,9 +478,6 @@ export default class TabRegion extends React.Component {
 
     }
     hoverAction(newHoverState) {
-        if (FSBL.Clients.WindowClient.shouldIgnoreTabbingRequests()) {
-            return;
-        }
         this.setState({ hoverState: newHoverState });
     }
 


### PR DESCRIPTION
**Resolves issue [10448-10449](https://chartiq.kanbanize.com/ctrl_board/18/cards/10447/subtasks)**

**Description of change**
- Changes the 'isArrangable' prop to the correct spelling/usage
- Sets showTabs to false to keep this component from being tabbable on other components

**Description of testing**
- In tandem with finsemble branch: https://github.com/ChartIQ/finsemble/pull/981
- Ensure that the app catalog cannot be tabbed with/snapped to and cannot tab out to other components/snap to other components.
