### PR TITLE
[AppLauncher] Disallow My apps and Favorites reorder

### DIFF
--- a/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
+++ b/src-built-in/components/appLauncher2/src/components/FoldersList.jsx
@@ -6,6 +6,7 @@ import { FinsembleDraggable, FinsembleDialog } from '@chartiq/finsemble-react-co
 
 const MY_APPS = 'My Apps'
 const DASHBOARDS = 'Dashboards'
+const FAVORITES = 'Favorites'
 
 export default class FoldersList extends React.Component {
 
@@ -166,6 +167,7 @@ export default class FoldersList extends React.Component {
 	}
 
 	renderFoldersList() {
+		const dragDisabled = [MY_APPS, DASHBOARDS, FAVORITES]
 		const folders = storeActions.getFolders()
 		return this.state.foldersList.map((folderName, index) => {
 			const folder = folders[folderName]
@@ -179,7 +181,7 @@ export default class FoldersList extends React.Component {
 					onChange={this.changeFolderName}
 					onKeyPress={this.keyPressed} autoFocus /> : folderName
 
-			return <FinsembleDraggable
+			return <FinsembleDraggable isDragDisabled={dragDisabled.indexOf(folderName) > -1} 
 				draggableId={folderName}
 				key={index} index={index}>
 				<div onClick={(event) => this.onFolderClicked(event, folderName)}

--- a/src-built-in/components/appLauncher2/src/components/LeftNav.jsx
+++ b/src-built-in/components/appLauncher2/src/components/LeftNav.jsx
@@ -22,18 +22,26 @@ export default class LeftNav extends React.Component {
 		super(props)
 	}
 
-	onDragEnd(event) {
+	onDragEnd(event = {}) {
 		console.log('on drag end');
 		// storeActions.reorderFolders(
 		// 	event.destination.index,
 		// 	event.source.index)
+
+		// Don't allow the destination to be my apps or favorites
+		// This is a quick and easy and clean way, avoiding big change
+		// for now
+		if(event.destination && event.destination.index <= 1) {
+			return
+		}
+
 		storeActions.reorderFolders(event.source.index, event.destination.index);
 	}
 
 	render() {
 		return (
 			<div className="complex-menu-left-nav">
-				<FinsembleDnDContext onDragEnd={this.onDragEnd}>
+				<FinsembleDnDContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
 					<FinsembleDroppable direction="vertical" droppableId="folderList">
 				  		<FoldersList />
 				  	</FinsembleDroppable>

--- a/src-built-in/components/appLauncher2/src/components/LeftNav.jsx
+++ b/src-built-in/components/appLauncher2/src/components/LeftNav.jsx
@@ -31,11 +31,13 @@ export default class LeftNav extends React.Component {
 		// Don't allow the destination to be my apps or favorites
 		// This is a quick and easy and clean way, avoiding big change
 		// for now
-		if(event.destination && event.destination.index <= 1) {
-			return
+		let newIndex = event.destination.index;
+		if(event.destination && newIndex <= 1) {
+			newIndex = 2;
 		}
 
-		storeActions.reorderFolders(event.source.index, event.destination.index);
+		storeActions.reorderFolders(event.source.index, newIndex);
+
 	}
 
 	render() {


### PR DESCRIPTION
**Resolves issue [#10408](https://chartiq.kanbanize.com/ctrl_board/18/cards/10408/details)**

**Description of change**
- Disable dragging on my apps and favorites
- Ignoring the reorder if the destination is My apps or Favorites

