### PR TITLE
[AppLauncher] [AppCatalog] View app info

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -28,7 +28,7 @@
 									"apps": {
 										"1": {
 											"name": "Welcome",
-											"appID": "1"
+											"appID": "welcome-comp"
 										},
 										"2": {
 											"name": "Getting Started Tutorial",
@@ -53,8 +53,8 @@
 							}
 						},
 						"appDefinitions": {
-							"1": {
-								"appID": "1",
+							"welcome-comp": {
+								"appID": "welcome-comp",
 								"name": "Welcome",
 								"source": "FDC3",
 								"tags": [

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -46,6 +46,7 @@ export default class AppMarket extends React.Component {
 		this.getPageContents = this.getPageContents.bind(this);
 		this.determineActivePage = this.determineActivePage.bind(this);
 		this.navigateToShowcase = this.navigateToShowcase.bind(this);
+		this.viewApp = this.viewApp.bind(this);
 	}
 	async componentDidMount() {
 		this.setState({
@@ -55,11 +56,19 @@ export default class AppMarket extends React.Component {
 		getStore().addListener({ field: 'installed' }, this.installedAppsChanged);
 		getStore().addListener({ field: 'filteredApps' }, this.filteringApps);
 		getStore().addListener({ field: 'activeApp' }, this.openAppShowcase);
+		// Get notified when user wants to view an app
+		FSBL.Clients.RouterClient.addListener("viewApp", this.viewApp)
 	}
 	componentWillUnmount() {
 		getStore().removeListener({ field: 'filteredApps' }, this.filteringApps);
 		getStore().removeListener({ field: 'installed' }, this.installedAppsChanged);
 		getStore().removeListener({ field: 'activeApp' }, this.openAppShowcase);
+		// Get notified when user wants to view an app
+		FSBL.Clients.RouterClient.removeListener("viewApp", this.viewApp)
+	}
+
+	viewApp(error, event) {
+		!error && this.navigateToShowcase(event.data.app.appID)
 	}
 	/**
 	 * The store has pushed an update to the filtered tags list. This means a user has begun searching or added tags to the filter list

--- a/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
@@ -66,9 +66,12 @@ export default class AppActionsMenu extends React.Component {
 				spawnIfNotFound: true,
 				left: "center",
 				top: "center"
-			}, () => {
-				//TODO: Make this work. There is logic already in the catalog store for opening an apps info page. But calling it directly from here won't work.
-				catalogActions.openApp(this.props.app.appId);
+			}, (error) => {
+				// Publish this event so that catalog knows
+				// what app we want to view
+				FSBL.Clients.RouterClient.transmit("viewApp", {
+					app: this.props.app
+				})
 		});
 	}
 

--- a/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/appLauncher2/src/components/AppActionsMenu.jsx
@@ -69,9 +69,14 @@ export default class AppActionsMenu extends React.Component {
 			}, (error) => {
 				// Publish this event so that catalog knows
 				// what app we want to view
-				FSBL.Clients.RouterClient.transmit("viewApp", {
-					app: this.props.app
-				})
+
+
+				//NOTE: While not ideal, without a small delay (when having to launch the app catalog) the app catalog wont recieve the message as it will still be initializing
+				setTimeout(() => {
+					FSBL.Clients.RouterClient.transmit("viewApp", {
+						app: this.props.app
+					})
+				}, 250);
 		});
 	}
 


### PR DESCRIPTION
**Resolves issue [#10407](https://chartiq.kanbanize.com/ctrl_board/18/cards/10407/details)**

**Description of change**
- Modified Welcome component id to match one in appd
- Transmit `viewApp` whenever user clicks on `view info`
- Listen for `viewApp` events in appCatalog app.jsx

**Description of testing**
Open launcher and catalog, open welcome app actions menu and click on `view info`, app catalog should be brought to front and switched to welcome app info page.
