### PR TITLE
10637 Pressing cancel locks the user out from switching workspaces.

### DIFF
--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -402,10 +402,8 @@ Actions = {
 			Logger.system.error(err);
 		}
 
-		//if there's no error, or there is an error and the user has cancelled the switch, we unlock the UI.
-		if (!err || err && err === SAVE_DIALOG_CANCEL_ERROR) {
-			switching = false;
-		}
+		//Unlock the UI.
+		switching = false;
 	},
 	/**
 	 * NOTE: Leaving this function here until we figure out notifications.

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -379,7 +379,9 @@ Actions = {
 
 			async.waterfall(tasks, Actions.onAsyncComplete);
 		} else {
-			switchIt();
+			switchIt(() => {
+				switching = false;
+			});
 		}
 	},
 

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -335,12 +335,10 @@ Actions = {
 		 * Actually perform the switch. Happens after we ask the user what they want.
 		 *
 		 */
-		function switchIt() {
+		function switchIt(callback) {
 			FSBL.Clients.WorkspaceClient.switchTo({
 				name: name
-			}, () => {
-				switching = false;
-			});
+			}, callback);
 		}
 		/**
 		 * Make sure the user wants to do what they say that they want to do.
@@ -402,6 +400,11 @@ Actions = {
 		if (err && err !== "Negative" && err !== SAVE_DIALOG_CANCEL_ERROR) {
 			//handle error.
 			Logger.system.error(err);
+		}
+
+		//if there's no error, or there is an error and the user has cancelled the switch, we unlock the UI.
+		if (!err || err && err === SAVE_DIALOG_CANCEL_ERROR) {
+			switching = false;
 		}
 	},
 	/**


### PR DESCRIPTION
Now we set the `switching` boolean to false inside of `onAsyncComplete`,
which happens after the workspace is switched _or_ the action is cancelled.

**Resolves issue [10637](https://chartiq.kanbanize.com/ctrl_board/18/cards/10637/details)**

**Description of change**
-`switching` was only being set to false inside of the `switchTo` callback. This PR changes that to `onAsyncComplete`.

**Description of testing**
-Move window, switch workspace. Click No. Workspace comes back without changes saved.
-Move window, switch workspace. Click Yes. Workspace comes back with changes saved.
-Move window, switch workspace. Click Cancel. Nothing happens.
-Move window, switch workspace. Switching workspaces is possible.