### PR TITLE
Changed server address to localhost.chartiq.com for websocket connection

### DIFF
--- a/configs/openfin/manifest-local.json
+++ b/configs/openfin/manifest-local.json
@@ -72,7 +72,7 @@
             "$applicationRoot/configs/application/config.json"
         ],
         "IAC": {
-            "serverAddress" : "wss://127.0.0.1:3376"
+            "serverAddress" : "wss://localhost.chartiq.com:3376"
         }
     }
 }


### PR DESCRIPTION
IAC should use localhost.chartiq.com for WSS connection rather than 127.0.0.1.
