### PR TITLE
10021 Only resize the window when it is mounted

### DIFF
--- a/src-built-in/components/linker/src/linker.jsx
+++ b/src-built-in/components/linker/src/linker.jsx
@@ -63,13 +63,12 @@ class Linker extends React.Component {
 	componentWillMount() {
 		finsembleWindow.addEventListener("blurred", this.onWindowBlur.bind(this));
 		LinkerStore.addListener(["stateChanged"], this.onStoreChanged);
-		LinkerActions.windowMounted(); //windowMounted
 		this.setState({
 			channels: LinkerStore.getChannels(),
 			attachedWindowIdentifier: LinkerStore.getAttachedWindowIdentifier()
 		});
 	}
-	componentDidUpdate() {
+	componentDidMount() {
 		LinkerActions.windowMounted();
 	}
 	render() {


### PR DESCRIPTION
**Resolves issue [10021](https://chartiq.kanbanize.com/ctrl_board/18/cards/10021/details)**

**Description of change**
- Only call fitToDom when the component is mounted

**Description of testing**
- The first time the linker is opened, it should be the correct size.
