### PR TITLE
[App Launcher] [App Catalog] 10718 switch between app launchers

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -13,6 +13,16 @@
 		}
 	},
 	"servicesConfig": {
+		"assimilation": {
+			"useOpenFinSpawn": false,
+			"enabled": true,
+			"blacklist": [],
+			"whitelist": [],
+			"onlySpawned": true,
+			"throttle": 10,
+			"focusDelay": 30,
+			"eventIgnore": 50
+		},
 		"distributedStore": {
 			"initialStores": [
 				{
@@ -145,18 +155,7 @@
 	"showNativeTabs": true,
 	"floatingTitlebarComponent": "Floating Titlebar"
 },
-"betaFeatures": {
-	"assimilation": {
-		"useOpenFinSpawn": false,
-		"enabled": true,
-		"blacklist": [],
-		"whitelist": [],
-		"onlySpawned": true,
-		"throttle": 10,
-		"focusDelay": 30,
-		"eventIgnore": 50
-	}
-},
+"betaFeatures": {},
 "splinteringConfig": {
 	"comment": "A SplinterAgent is just an openfin application that is capable of spawning specific components/services. If you try to spawn a component/service that one of these agents does not cover, it will be spawned by the defaultAgent. You can also specify maxWindowsPerAgent if you would like to limit your agents to some ceiling. This is useful when you have a particularly heavy component.",
 	"enabled": true,

--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -58,6 +58,9 @@
 					}
 				},
 				"components": {
+					"App Launcher": {
+						"launchableByUser": false
+					},
 					"Window Manager": {
 						"persistWindowState": false,
 						"FSBLHeader": false,
@@ -549,7 +552,8 @@
 				},
 				"components": {
 					"App Launcher": {
-						"launchableByUser": false
+						"launchableByUser": false,
+						"menuVersion": 2
 					},
 					"Window Manager": {
 						"persistWindowState": false,

--- a/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
@@ -60,7 +60,7 @@ export default class AppActionsMenu extends React.Component {
 		this.toggleMenu();
 		FSBL.Clients.LauncherClient.showWindow(
 			{
-				componentType: "App Catalog 2"
+				componentType: "App Catalog"
 			},
 			{
 				monitor: "mine",

--- a/src-built-in/components/myApps/src/index.jsx
+++ b/src-built-in/components/myApps/src/index.jsx
@@ -30,7 +30,7 @@ class AppLauncher extends React.Component {
 	openAppMarket() {
 		FSBL.Clients.LauncherClient.showWindow(
 			{
-				componentType: "App Catalog 2"
+				componentType: "App Catalog"
 			},
 			{
 				monitor: "mine",

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -60,7 +60,6 @@ class _ToolbarStore {
 	retrieveSelfFromStorage(cb) {
 
 		finsembleWindow.getOptions((err, opts) => {
-			console.info("get options", opts);
 			let hasRightProps = () => {
 				return (opts.hasOwnProperty('customData') &&
 					opts.customData.hasOwnProperty('foreign') &&
@@ -138,14 +137,27 @@ class _ToolbarStore {
 				});
 				done();
 			} else {
-				self.Store.setValue({
-					field: "menus",
-					value: menuConfig
+				finsembleWindow.getOptions((err, opts) => {
+					let version = opts.customData.foreign.components["App Launcher"].menuVersion;
+					if (!version) {
+						version = 1;
+					}
+					let newMenuConfig = menuConfig.map((configProp) => {
+						let newConfigProp = configProp;
+						if (configProp.id === 'app-launcher' && version === 2) {
+							newConfigProp.menuType = "My Apps";
+						}
+						return newConfigProp;
+					});
+					self.Store.setValue({
+						field: "menus",
+						value: newMenuConfig
+					});
+					done();
+					if (FSBL.Clients.ConfigClient.setValue) {
+						FSBL.Clients.ConfigClient.setValue({ field: "finsemble.menus", value: newMenuConfig });
+					}
 				});
-				done();
-				if (FSBL.Clients.ConfigClient.setValue) {
-					FSBL.Clients.ConfigClient.setValue({ field: "finsemble.menus", value: menuConfig });
-				}
 			}
 		});
 	}


### PR DESCRIPTION
**Resolves issue [10718](https://chartiq.kanbanize.com/ctrl_board/18/cards/10718/details)**

**Description of change**
- Moves assimilation config out of beta features
- Adds `menuVersion` prop to `foreign.components["App Launcher"]` which will determine which version of the apps menu will show to the user. If any value other than 1 or 2 is supplied, it will default to 1 (the old launcher)

**Description of testing**
- Change `foreign.components["App Launcher"].menuVersion` to 1 or 2 and reset Finsemble. If menuVersion is 1, the old app launcher will show. If 2, the new one. Any other value will result in old app launcher.
