### PR TITLE
[AppLauncher] 10754 ability to pin adhoc components

### DIFF
--- a/configs/openfin/manifest-local.json
+++ b/configs/openfin/manifest-local.json
@@ -57,8 +57,8 @@
     "fileName": "ChartIQ-local-installer",
     "appAssets": [
         {
-            "src": "https://connect2.chartiq.com/finsemble/Assimilation_3_0_1.zip",
-            "version": "3.0.1",
+            "src": "https://connect2.chartiq.com/finsemble/Assimilation_2_0_3.zip",
+            "version": "2.0.3",
             "alias": "assimilation",
             "target": "assimilationMain.exe"
         }

--- a/configs/openfin/manifest-local.json
+++ b/configs/openfin/manifest-local.json
@@ -57,8 +57,8 @@
     "fileName": "ChartIQ-local-installer",
     "appAssets": [
         {
-            "src": "https://connect2.chartiq.com/finsemble/Assimilation_2_0_3.zip",
-            "version": "2.0.3",
+            "src": "https://connect2.chartiq.com/finsemble/Assimilation_3_0_1.zip",
+            "version": "3.0.1",
             "alias": "assimilation",
             "target": "assimilationMain.exe"
         }

--- a/src-built-in/components/appLauncher2/src/stores/StoreActions.js
+++ b/src-built-in/components/appLauncher2/src/stores/StoreActions.js
@@ -195,6 +195,8 @@ function addApp(app = {}, cb) {
 	FSBL.Clients.LauncherClient.addUserDefinedComponent(data.apps[appID], (compAddErr) => {
 		if (compAddErr) {
 			//TODO: We need to handle the error here. If the component failed to add, we should probably fall back and not add to launcher
+			console.warn("Failed to add new app");
+			return;
 		}
 		// Save appDefinitions and then folders
 		_setValue('appDefinitions', data.apps, () => {
@@ -205,18 +207,25 @@ function addApp(app = {}, cb) {
 }
 
 function deleteApp(appID) {
-	// Delete app from any folder that has it
-	for(const key in data.folders) {
-		if(data.folders[key].apps[appID]) {
-			delete data.folders[key].apps[appID]
+	ToolbarStore.removeValue({ field: 'pins.' + data.apps[appID].name.replace(/[.]/g, "^DOT^") }, (err, res) => {
+		if (err) {
+			//TODO: Need to gracefully handle this error. If the pin can't be removed, the app shouldn't either
+			console.warn("Error removing pin for deleted app");
+			return
 		}
-	}
-	// Delete app from the apps list
-	delete data.apps[appID]
-	// Save appDefinitions and then folders
-	_setValue('appDefinitions', data.apps, () => {
-		_setFolders()
-	})
+		// Delete app from any folder that has it
+		for(const key in data.folders) {
+			if(data.folders[key].apps[appID]) {
+				delete data.folders[key].apps[appID]
+			}
+		}
+		// Delete app from the apps list
+		delete data.apps[appID]
+		// Save appDefinitions and then folders
+		_setValue('appDefinitions', data.apps, () => {
+			_setFolders()
+		})
+	});
 }
 
 function addNewFolder(name) {

--- a/src-built-in/components/appLauncher2/src/stores/StoreActions.js
+++ b/src-built-in/components/appLauncher2/src/stores/StoreActions.js
@@ -141,6 +141,7 @@ function addPin(pin) {
 			ToolbarStore.setValue({ field: 'pins.' + pin.name.replace(/[.]/g, "^DOT^"), value: thePin });
 		}
 	});
+
 }
 
 function removePin(pin) {
@@ -191,11 +192,16 @@ function addApp(app = {}, cb) {
 	}
 	data.folders[MY_APPS].apps[appID] = data.apps[appID]
 	data.folders[folder].apps[appID] = data.apps[appID]
-	// Save appDefinitions and then folders
-	_setValue('appDefinitions', data.apps, () => {
-		_setFolders()
-		cb && cb()
-	})
+	FSBL.Clients.LauncherClient.addUserDefinedComponent(data.apps[appID], (compAddErr) => {
+		if (compAddErr) {
+			//TODO: We need to handle the error here. If the component failed to add, we should probably fall back and not add to launcher
+		}
+		// Save appDefinitions and then folders
+		_setValue('appDefinitions', data.apps, () => {
+			_setFolders()
+			cb && cb()
+		})
+	});
 }
 
 function deleteApp(appID) {


### PR DESCRIPTION
**Resolves issue [10754](https://chartiq.kanbanize.com/ctrl_board/18/cards/10754/details)**

**Description of change**
- When an adhoc component is added, FSBL is called to add the component

**Description of testing**
- Verify that an adhoc component added at runtime can pin and unpin from the taskbar using the 'favorite' feature
