### PR TITLE
double click to maximize sometimes doesnt work

### DIFF
--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -151,9 +151,14 @@ var Actions = {
 		/**
 		 * Catches a double-click on the title bar. If you don't catch this, openfin will invoke the OS-level maximize, which will put the window on top of the toolbar. `clickMaximize` will fill all of the space that finsemble allows.
 		 */
-		FSBL.Clients.WindowClient.finWindow.addEventListener("maximized", function () {
-			self.clickMaximize();
+		finsembleWindow.addEventListener("maximized", function () {
+			windowTitleBarStore.setValue({ field: "Maximize.maximized", value: true });
 		});
+
+		finsembleWindow.addEventListener("restored", function () {
+			windowTitleBarStore.setValue({ field: "Maximize.maximized", value: false });
+		});
+
 
 		//default title.
 		windowTitleBarStore.setValue({ field: "Main.windowTitle ", value: FSBL.Clients.WindowClient.getWindowTitle() });
@@ -387,15 +392,9 @@ var Actions = {
 	clickMaximize: function () {
 		var maxField = windowTitleBarStore.getValue({ field: "Maximize" });
 		if (finsembleWindow.windowState !== finsembleWindow.WINDOWSTATE.MAXIMIZED)
-			return FSBL.Clients.WindowClient.maximize(() => {
-				windowTitleBarStore.setValue({ field: "Maximize.maximized", value: true });
-			});
+			return FSBL.Clients.WindowClient.maximize();
 
-		return FSBL.Clients.WindowClient.restore(() => {
-			windowTitleBarStore.setValue({ field: "Maximize.maximized", value: false });
-		});
-
-
+		return FSBL.Clients.WindowClient.restore();
 	},
 
 	getTabs() {


### PR DESCRIPTION
**Resolves issue [10781](https://chartiq.kanbanize.com/ctrl_board/18/cards/10781/details)**

**Description of change**
- Remove finWindow listener. Change icon state based on finsembleWindows listeners on maximized/restored.

- ALSO NEEDS CORRESPONDING FINSEMBLE PR 

**Description of testing**
- Double Click Titlebar in Stack. Make sure it maximizes and icons are correct. Double Click again and restore
- Double click Titlebar in Badboy component while render is blocked. Make suremaximize eventually succeeds, as does restore.