### PR TITLE
10326 Fix drag handler when window scrolls before titlebar load

### DIFF
--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -7,7 +7,7 @@
     /* use below with window scrollbar hack */
     position: fixed;
     top: 5px!important;
-    margin-top: 0px!important;
+    margin-top: 0px !important;
     /* use below without window scrollbar hack */
     /* position: absolute; */
     /* top: 0px!important; */

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -219,7 +219,7 @@ class WindowTitleBar extends React.Component {
 		// header bar with dynamic height!
 		let bounds = fsblHeader.getBoundingClientRect();
 		dragHandle.style.height = (bounds.height - 5) + "px"; // Subtract 5 pixels from height in order to make room for resize window cursor at top edge of window
-		dragHandle.style.marginTop = (-bounds.height + 5) + "px"; // Negative margin pulls the drag handle up over the fixed header
+		dragHandle.style.setProperty("margin-top", (-bounds.height) + "px", "important"); // Negative margin pulls the drag handle up over the fixed header
 
 		// Start logic for determining where to place our dragHandle
 		if (this.state.showTabs) {


### PR DESCRIPTION
**Resolves issue [10693](https://chartiq.kanbanize.com/ctrl_board/18/cards/10693/details)**

**Description of change**
- Changes the drag handler style changes to use 'setProperty' instead of accessing directly. This allows for the setting of property priority.
- Fixes a css type for window titlebars

**Description of testing**
- Create an adhoc component and spawn. Relead component and scroll before the page loads. Once the windowTitlebar is injected, make sure the window is still movable.

**NOTE: The old code was removing 5 pixels from the height to determine the negative margin of the drag handler, this caused a small deadzone near the tab/title. The 5 pixels was removed**
