### PR TITLE
10326 scroll before ready

### DIFF
--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -7,7 +7,7 @@
     /* use below with window scrollbar hack */
     position: fixed;
     top: 5px!important;
-    margin-top: 0px!important;
+    margin-top: 0px !important;
     /* use below without window scrollbar hack */
     /* position: absolute; */
     /* top: 0px!important; */

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -219,7 +219,7 @@ class WindowTitleBar extends React.Component {
 		// header bar with dynamic height!
 		let bounds = fsblHeader.getBoundingClientRect();
 		dragHandle.style.height = (bounds.height - 5) + "px"; // Subtract 5 pixels from height in order to make room for resize window cursor at top edge of window
-		dragHandle.style.setProperty("margin-top", (-bounds.height) + "px", "important"); // Negative margin pulls the drag handle up over the fixed header
+		if (document.body.scrollHeight > finsembleWindow.windowOptions.height) dragHandle.style.setProperty("margin-top", (-bounds.height) + "px", "important"); // Negative margin pulls the drag handle up over the fixed header
 
 		// Start logic for determining where to place our dragHandle
 		if (this.state.showTabs) {

--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -219,7 +219,7 @@ class WindowTitleBar extends React.Component {
 		// header bar with dynamic height!
 		let bounds = fsblHeader.getBoundingClientRect();
 		dragHandle.style.height = (bounds.height - 5) + "px"; // Subtract 5 pixels from height in order to make room for resize window cursor at top edge of window
-		dragHandle.style.marginTop = (-bounds.height + 5) + "px"; // Negative margin pulls the drag handle up over the fixed header
+		dragHandle.style.setProperty("margin-top", (-bounds.height) + "px", "important"); // Negative margin pulls the drag handle up over the fixed header
 
 		// Start logic for determining where to place our dragHandle
 		if (this.state.showTabs) {


### PR DESCRIPTION
**Resolves issue [10326](https://chartiq.kanbanize.com/ctrl_board/18/cards/10326/details)**

Adds a -25px top margin to a component that has a larger scrollHeight than window height. This is unfortunately only needed when the component is scrolled before the title bar is injected. Since the drag handler already has an important 0px top margin, we have to overwrite it with an important property _when its needed_. I have yet to solve _HOW_ to determine  if its needed.
