### PR TITLE
[App Launcher] Fixes bug where pins were added regardless of folder u…

### DIFF
--- a/src-built-in/components/myApps/src/components/FoldersList.jsx
+++ b/src-built-in/components/myApps/src/components/FoldersList.jsx
@@ -30,14 +30,13 @@ export default class FoldersList extends React.Component {
 	onAppDrop(event, folder) {
 		event.preventDefault()
 		const app = JSON.parse(event.dataTransfer.getData('app'))
-		//TODO: When adding to favorite do more stuff?
-		if (folder.name === 'Favorites') {
-			console.info('Dropped app in favorites.')
-		}
 		// Do not do anything if its my apps or dashboards folder
 		if ([MY_APPS, DASHBOARDS].indexOf(folder) < 0) {
 			storeActions.addAppToFolder(folder, app);
-			storeActions.addPin(app);
+			if (folder === FAVORITES) {
+				//If favorites, then also pin
+				storeActions.addPin(app);
+			}
 		}
 	}
 
@@ -173,7 +172,7 @@ export default class FoldersList extends React.Component {
 					onChange={this.changeFolderName}
 					onKeyPress={this.keyPressed} className={this.state.isNameError ? "error" : ""} autoFocus /> : folderName
 
-			return <FinsembleDraggable isDragDisabled={dragDisabled.indexOf(folderName) > -1} 
+			return <FinsembleDraggable isDragDisabled={dragDisabled.indexOf(folderName) > -1}
 				draggableId={folderName}
 				key={index} index={index}>
 				<div onClick={(event) => this.onFolderClicked(event, folderName)}

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -96,7 +96,6 @@ function _setValue(field, value, cb) {
 
 function addPin(pin) {
 	//TODO: This logic may not work for dashboards. Might need to revisit.
-	console.log('pin: ', pin);
 	FSBL.Clients.LauncherClient.getComponentList((err, components) => {
 		let componentToToggle;
 		for (let i = 0; i < Object.keys(components).length; i++) {

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -96,11 +96,14 @@ function _setValue(field, value, cb) {
 
 function addPin(pin) {
 	//TODO: This logic may not work for dashboards. Might need to revisit.
+	console.log('pin: ', pin);
 	FSBL.Clients.LauncherClient.getComponentList((err, components) => {
 		let componentToToggle;
 		for (let i = 0; i < Object.keys(components).length; i++) {
 			let componentName = Object.keys(components)[i];
-			if (componentName === pin.name) {
+			//pin name "Welcome" will not be found in component list with "Welcome Component".
+			//Will check both for actual name, and for pin.name + Component against the list
+			if (componentName === pin.name || componentName === pin.name + " Component") {
 				componentToToggle = components[componentName];
 			}
 		}


### PR DESCRIPTION
…ser drags to

**Resolves issue [10871](https://chartiq.kanbanize.com/ctrl_board/18/cards/10871/details)**

**Description of change**
- Fixes app folder dragging logic so now a pin will only be added when the user drags to the favorites folder
- Fixed the welcome component pin (inconsistencies between pin name and whats returned by FSBL.getComponentList)

**Description of testing**
- When an app is dragged into a folder it should be placed in that folder, but a pin should only be added to the toolbar when an item is dragged to the Favorites folder. The welcome component is now pinnable as well.
