### PR TITLE
10905 e2o fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -382,7 +382,7 @@
 			});
 
 			let e2oLocation = "node_modules/@chartiq/e2o";
-			let electronPath = path.join(".", "/node_modules/electron/dist/electron.exe");
+			let electronPath = path.join("..", "..", "electron", "dist", "electron.exe");
 			let command = "set ELECTRON_DEV=true && " + electronPath + " index.js --remote-debugging-port=9090 --manifest " + manifest;
 			logToTerminal(command);
 			electronProcess = exec(command,


### PR DESCRIPTION
**Resolves issue [10905](https://chartiq.kanbanize.com/ctrl_board/18/cards/10905/details)**

**Description of change**
- [x] Update path of electron from node_modules to be correct.

**Description of testing**
Electron launching still works properly, but without requiring an additional npm install within `./node_modules/@chartiq/e2o`
