### PR TITLE
11123 Set category: system on nonConfiguredComponent

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -53,7 +53,8 @@
 			},
 			"component": {
 				"inject": false,
-				"spawnOnStartup": false
+				"spawnOnStartup": false,
+				"category": "system"
 			},
 			"foreign": {
 				"services": {


### PR DESCRIPTION
**Resolves issue [11123](https://chartiq.kanbanize.com/ctrl_board/18/cards/11123/details)**

**Description of change**
- nonConfiguredComponent should be marked as a system component and not drop out of config during dynamic config
