### PR TITLE
Disable toolbar drag handle when docking is disabled

### DIFF
--- a/src-built-in/components/toolbar/src/dynamicToolbar.jsx
+++ b/src-built-in/components/toolbar/src/dynamicToolbar.jsx
@@ -44,7 +44,8 @@ export default class Toolbar extends React.Component {
 		super(props);
 		this.state = {
 			sections: ToolbarStore.getSectionsFromMenus(),
-			finWindow: fin.desktop.Window.getCurrent()
+			finWindow: fin.desktop.Window.getCurrent(),
+			canDrag: false
 		};
 		this.bindCorrectContext();
 	}
@@ -62,6 +63,11 @@ export default class Toolbar extends React.Component {
 	componentDidMount() {
 		//console.log("this", this)
 		this.state.finWindow.bringToFront();
+		FSBL.Clients.ConfigClient.getValues({ field: "finsemble.components.Toolbar.window.dockable" }, (err, dockable) => {
+			this.setState({
+				canDrag: dockable
+			});
+		});
 	}
 
 	componentWillMount() {
@@ -173,7 +179,7 @@ export default class Toolbar extends React.Component {
 		//console.log("Toolbar Render ");
 		if (!this.state.sections) return;
 		return (<FinsembleToolbar onDragStart={this.moveToolbar} onDragEnd={this.onPinDrag}>
-			<DragHandle />
+			{this.state.canDrag && <DragHandle />} {/*If this is not dockable, no need to show the drag handle */}
 			{this.getSections()}
 			<div className='resize-area' />
 		</FinsembleToolbar>);


### PR DESCRIPTION
**Resolves issue [11175](https://chartiq.kanbanize.com/ctrl_board/18/cards/11175/details)**

**Description of change**
- Toolbar now checks its own dockable state and disabled drag handle when docking is disabled
- *REQUIRES*: https://github.com/ChartIQ/finsemble/pull/1041

**Description of testing**
-H Change 'dockable' to false in presentationComponents.json for 'Toolbar'. This will cause the drag handle to disappear and the toolbar will not be moveable
