### PR TITLE
9777 Makes 'allowTabbing' on a component invoke 'showTabs: false' in the t…

### DIFF
--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -186,7 +186,6 @@ var Actions = {
 			} else {
 				//If tabbing is enabled system-wide, look to the global config for its value. Then look to the local component's config.
 
-
 				//This is the global window manager config.
 				if (typeof windowTitleBarConfig.showTabs !== 'boolean') {
 					windowTitleBarStore.setValue({ field: "showTabs", value: globalWindowManagerConfig.showTabs });
@@ -195,6 +194,31 @@ var Actions = {
 				if (windowTitleBarConfig.showTabs || windowTitleBarConfig.showTabs === false) {
 					windowTitleBarStore.setValue({ field: "showTabs", value: windowTitleBarConfig.showTabs });
 				}
+
+				//Once the above has been checked the individual component config is checked for customData.foreign.services[windowService || dockingService][!ignoreTilingAndTabbingRequests || allowTabbing]
+				let showTabs = true;
+				finsembleWindow.getOptions((err, opts) => {
+					if (opts.customData && opts.customData.foreign && opts.customData.foreign.services) {
+						if (opts.customData.foreign.services.windowService) {
+							if (opts.customData.foreign.services.windowService.allowTabbing !== undefined) {
+								showTabs = opts.customData.foreign.services.windowService.allowTabbing;
+							} else if (opts.customData.foreign.services.windowService.ignoreTilingAndTabbingRequests != undefined) {
+								showTabs = !opts.customData.foreign.services.windowService.ignoreTilingAndTabbingRequests;
+							}
+						} else if (opts.customData.foreign.services.dockingService) {
+							if (opts.customData.foreign.services.dockingService.allowTabbing !== undefined) {
+								showTabs = opts.customData.foreign.services.dockingService.allowTabbing;
+							} else if (opts.customData.foreign.services.dockingService.ignoreTilingAndTabbingRequests != undefined) {
+								showTabs = !opts.customData.foreign.services.dockingService.ignoreTilingAndTabbingRequests;
+							}
+						}
+					}
+
+					windowTitleBarStore.setValue({ field: 'showTabs', value: showTabs });
+				});
+
+
+
 			}
 		});
 


### PR DESCRIPTION
…itlebar

**Resolves issue [9777](https://chartiq.kanbanize.com/ctrl_board/18/cards/9777/details)**

**Description of change**
- Component will read from config when windowTitleBar comes online. If a component spcifies that it does not want to allowTabbing, it will hide tabs in the same way `showTabs: false` does
- **REQUIRES:** https://github.com/ChartIQ/finsemble/pull/1024

**Description of testing**
- Make `ComponentName: foreign: services: windowService || dockingService: allowTabbing` false and the titlebar won't have tabs, only a window title that you can't move (as a tab)
