### PR TITLE
11352 update openfin versions

### DIFF
--- a/configs/openfin/manifest-local.json
+++ b/configs/openfin/manifest-local.json
@@ -22,11 +22,12 @@
     },
     "splashScreenImage": "http://localhost:3375/assets/img/FinsembleSplash.png",
     "runtime": {
-        "arguments": "--noerrdialogs  --v=4 --no-sandbox  --enable-crash-reporting --framestrategy=frames --winhttp-proxy-resolver",
-        "version": "8.56.28.36",
-        "///": "This version of OF9 can be used but has stability problems with splintering",
-        "version_of9": "9.61.36.36",
+        "arguments": "--noerrdialogs --v=4 --no-sandbox --framestrategy=frames --winhttp-proxy-resolver",
+        "version": "8.56.30.71",
+        "///": "This version of OF9 can be used but has problems with localstorage use in preloads - please contact support@finsemble.com for a build customisation to rectify if encountered",
+        "version_of9": "9.61.37.46",
         "//": "Add these arguments when diagnosing issues",
+        "--enable-crash-reporting": "Adding this to the runtimeArguments activates OpenFin crash reporting - known to cause a memory leak in 9.61.37.46.",
         "--diagnostics": "Adding this to the runtimeArguments activates verbose logging and crash reporting.",
         "--disable-gpu": "This flag disables hardware acceleration. Try this if 'Blank Screen' issues are reported (sometimes on virtual desktops)",
         "--winhttp-proxy-resolver": "Chromium v56 contains a bug that in some environments can create a memory leak. The bug is related to the way Chromium handles PAC files."


### PR DESCRIPTION
**Resolves issue [11352](https://chartiq.kanbanize.com/ctrl_board/18/cards/11352/details)**

**Description of change**
- Update OF8 version to latest
- Update OF9 version to latest
- Update advice in manifest re: OF9 use
- Disable `--enable-crash-reporter` runtimeArgument (due to mem leak in latest OF9) and move to advice

Have not set OF9 as default yet, due to ongoing issues with Localstorage and the advanced chart. See https://chartiq.kanbanize.com/ctrl_board/18/cards/11352/comments for more info.

**Description of testing**
-Switched OpenFin runtime.version to each OpenFin version, build, launch and perform manual tests
