### PR TITLE
Removes the code which kills electron on exit, this causes restart to…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -410,11 +410,13 @@
 			electronProcess.on("close", function (code) {
 				console.log("child process exited with code " + code);
 				//Server shouldn't shut down on exit because electron restart closes down electron and restarts in the background.
+				//Didn't want to remove the code in case problems are encountered in openfin with this change
 				// process.exit();
 			});
 
 			process.on('exit', function () {
 				//Server shouldn't shut down on exit because electron restart closes down electron and restarts in the background.
+				//Didn't want to remove the code in case problems are encountered in openfin with this change
 				// electronProcess.kill();
 			});
 			if (done) done();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -409,11 +409,13 @@
 
 			electronProcess.on("close", function (code) {
 				console.log("child process exited with code " + code);
-				process.exit();
+				//Server shouldn't shut down on exit because electron restart closes down electron and restarts in the background.
+				// process.exit();
 			});
 
 			process.on('exit', function () {
-				electronProcess.kill();
+				//Server shouldn't shut down on exit because electron restart closes down electron and restarts in the background.
+				// electronProcess.kill();
 			});
 			if (done) done();
 		},


### PR DESCRIPTION
… bork

**Resolves issue [11193](https://chartiq.kanbanize.com/ctrl_board/18/cards/11193/details)**

**Description of change**
- Removes the electronProcess.kill when all windows are closed. Since electron requires the process be quit to restart, this was causing the entire server to shut down on a restart
- Removes process kill for the same reason
- Requires [finsemble PR 1060](https://github.com/ChartIQ/finsemble/pull/1060)
- Requires [e2o PR 22](https://github.com/ChartIQ/e2o/pull/22)

**Description of testing**
- Make sure restart/quit works in electron
