### PR TITLE
standardise storage adapter logging and implementations

### DIFF
--- a/src-built-in/adapters/indexedDBAdapter.js
+++ b/src-built-in/adapters/indexedDBAdapter.js
@@ -1,7 +1,15 @@
-import finsemble from "@chartiq/finsemble";
+/**
+ * This file is a copy of the default IndexedDBAdapter adapter, the default storage model used by finsemble-seed.
+ * It's provided as an example. Feel free to modify, add to, or erase parts of it.
+ *
+ * Core Finsemble calls are written with key-value pair databases in mind. If you want to use a different database type, you will need to translate the key/value pairs passed in from finsemble so that you can successfully retrieve them at a later time.
+ */
 
-const BaseStorage = finsemble.models.baseStorage;
-const Logger = finsemble.Clients.Logger;
+/**
+ * We have a baseStorage model that provides some methods, such as `getCombinedKey`, which will return a nice key to save our value under. Example: `Finsemble:defaultUser:finsemble:activeWorkspace`. That key would hold the value of our activeWorkspace.
+ */
+const BaseStorage = require("@chartiq/finsemble").models.baseStorage;
+const Logger = require("@chartiq/finsemble").Clients.Logger;
 
 // Because calls to this storage adapter will likely come from many different windows, we will log successes and 
 // failures in the central logger.
@@ -63,13 +71,13 @@ IDBKeyRange.forPrefix = (prefix) => {
 // #endregion
 
 /**
- * IndexDB Storage Adapter.
+ * IndexedDB Storage Adapter.
  * 
  * We have a baseStorage model that provides some methods, such as `getCombinedKey`, which will return a nice key to 
  * save our value under. Example: `Finsemble:defaultUser:finsemble:activeWorkspace`. That key would hold the value of 
  * our activeWorkspace.
  */
-const IndexedDBAdapter = function () {
+const IndexedDBAdapter = function (uuid) {
 	// #region Initializes a new instance of the IndexedDBAdapter.
 	BaseStorage.call(this, arguments);
 
@@ -84,8 +92,8 @@ const IndexedDBAdapter = function () {
 	 */
 	this.queue = [];
 
-	Logger.system.debug("IndexedDBAdapter init");
-	console.debug("IndexedDBAdapter init");
+	Logger.system.log("IndexedDBAdapter init");
+	console.log("IndexedDBAdapter init");
 
 	// #region Initialize IndexedDB connection.
 	// Open the IndexedDB connection
@@ -109,8 +117,8 @@ const IndexedDBAdapter = function () {
 	};
 
 	request.onsuccess = (event) => {
-		Logger.system.debug("IndexedDBAdapter initialized successfully");
-		console.debug("IndexedDBAdapter initialized successfully");
+		Logger.system.log("IndexedDBAdapter initialized successfully");
+		console.log("IndexedDBAdapter initialized successfully");
 
 		this.db = event.target.result;
 		this.releaseQueue();
@@ -153,8 +161,8 @@ const IndexedDBAdapter = function () {
 	 */
 	this.releaseQueue = () => {
 		initialized = true;
-		Logger.system.debug(`IndexedDBAdapter.releaseQueue: ${this.queue.length} commands`);
-		console.debug(`IndexedDBAdapter.releaseQueue: ${this.queue.length} commands`);
+		Logger.system.log(`IndexedDBAdapter.releaseQueue: ${this.queue.length} commands`);
+		console.log(`IndexedDBAdapter.releaseQueue: ${this.queue.length} commands`);
 
 		while (this.queue.length) {
 			const action = this.queue.shift();
@@ -176,25 +184,25 @@ const IndexedDBAdapter = function () {
 
 		const userPreface = this.getUserPreface(this);
 
-		Logger.system.debug("IndexedDBAdapter.clearCache for userPreface=" + userPreface);
-		console.debug("IndexedDBAdapter.clearCache for userPreface=" + userPreface);
+		Logger.system.log("IndexedDBAdapter.clearCache for userPreface=" + userPreface);
+		console.log("IndexedDBAdapter.clearCache for userPreface=" + userPreface);
 
 		const keyRange = IDBKeyRange.forPrefix(userPreface);
 		const objectStore = this.db.transaction(["fsbl"], "readwrite").objectStore("fsbl");
 		const request = objectStore.delete(keyRange);
 
 		request.onsuccess = () => {
-			Logger.system.debug("IndexedDBAdapter.clearCache Success: userPreface=" + userPreface);
-			console.debug("IndexedDBAdapter.clearCache Success: userPreface=" + userPreface);
+			Logger.system.log("IndexedDBAdapter.clearCache Success: userPreface=" + userPreface);
+			console.log("IndexedDBAdapter.clearCache Success: userPreface=" + userPreface);
 
-			cb();
+			cb(null, { status: "success" });
 		};
 
 		request.onerror = (err) => {
 			Logger.system.error("IndexedDBAdapter.clearCache failed Error", err, "userPreface=" + userPreface);
 			console.error("IndexedDBAdapter.clearCache failed Error", err, "userPreface=" + userPreface);
 
-			return cb(err, { status: "failed" });
+			cb(err, { status: "failed" });
 		};
 	}
 
@@ -233,7 +241,7 @@ const IndexedDBAdapter = function () {
 			Logger.system.error("IndexedDBAdapter.delete key=" + combinedKey + ", Error", err);
 			console.error("IndexedDBAdapter.delete key=" + combinedKey + ", Error", err);
 
-			return cb(err, { status: "failed" });
+			cb(err, { status: "failed" });
 		};
 	}
 
@@ -249,8 +257,8 @@ const IndexedDBAdapter = function () {
 			return;
 		}
 
-		Logger.system.debug("IndexedDBAdapter.empty");
-		console.debug("IndexedDBAdapter.empty");
+		Logger.system.log("IndexedDBAdapter.empty");
+		console.log("IndexedDBAdapter.empty");
 
 		const objectStore = this.db.transaction(["fsbl"], "readwrite").objectStore("fsbl");
 		const request = objectStore.clear();
@@ -263,8 +271,8 @@ const IndexedDBAdapter = function () {
 		};
 
 		request.onsuccess = () => {
-			Logger.system.debug("IndexedDBAdapter.empty Success");
-			console.debug("IndexedDBAdapter.empty Success");
+			Logger.system.log("IndexedDBAdapter.empty Success");
+			console.log("IndexedDBAdapter.empty Success");
 
 			cb();
 		};
@@ -287,7 +295,7 @@ const IndexedDBAdapter = function () {
 		}
 
 		Logger.system.debug("IndexedDBAdapter.get, params: ", params);
-		console.debug("IndexedDBAdapter.get, params: ", params, cb);
+		console.debug("IndexedDBAdapter.get, params: ", params);
 
 		const combinedKey = this.getCombinedKey(this, params);
 		const objectStore = this.db.transaction(["fsbl"], "readwrite").objectStore("fsbl");
@@ -295,7 +303,7 @@ const IndexedDBAdapter = function () {
 
 		request.onsuccess = (event) => {
 			let data;
-			if(event.target.result) data = event.target.result.value;
+			if (event.target.result) data = event.target.result.value;
 
 			Logger.system.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);
 			console.debug("IndexedDBAdapter.get for key=" + combinedKey + " data=", data);
@@ -348,7 +356,7 @@ const IndexedDBAdapter = function () {
 			Logger.system.error("Failed to retrieve IndexedDBAdapter.keys keyPreface=" + keyPreface + ", Error", err);
 			console.error("Failed to retrieve IndexedDBAdapter.keys keyPreface=" + keyPreface + ", Error", err);
 
-			return cb(err, { status: "failed" });
+			cb(err, { status: "failed" });
 		};
 	}
 
@@ -395,3 +403,4 @@ const IndexedDBAdapter = function () {
 
 IndexedDBAdapter.prototype = new BaseStorage();
 new IndexedDBAdapter("IndexedDBAdapter");
+module.exports = IndexedDBAdapter;//Allows us to get access to the uninitialized object


### PR DESCRIPTION
LocalStorageAdapter updated to standardise its callback use and match logging to IndexedDBAdapter. Fix IndexedDBAdapter exports.

**(Helps) Resolves issue [11497](https://chartiq.kanbanize.com/ctrl_board/18/cards/11497/details)**

**Description of change**
-During storage debug for client, standardised the storage adapter implementations and logging. Ensuring that the LocalStorageAdapter provides a better example amnd doesn't include anti-patterns (like retuning success statuses after receiving an error back from a storage op). THese anti-patterns where replicated by client's code.

**Description of testing**
-Ran finsemble with clear cache and both storage adapters mapped to topics. Confirmed that they successfully completed get and save storage ops and that logging was correct/matched to ease debug. 
