### PR TITLE
Don't enable allowRename if trying to rename active workspace, this a…

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -493,8 +493,9 @@ export default class Workspaces extends React.Component {
 												{workspace.name}
 											</div>
 											<div className="individual-workspace-actions">
+												{workspace.name !== FSBL.Clients.WorkspaceClient.activeWorkspace.name &&
 												<div title={renameTooltip} className={renameButtonClasses} onMouseDown={this.handleButtonClicks} onClick={
-													allowRename ? () => { this.startEditingWorkspace(workspace.name) } : Function.prototype}><i className="ff-edit"></i></div>
+													allowRename ? () => { this.startEditingWorkspace(workspace.name) } : Function.prototype}><i className="ff-edit"></i></div>}
 												{workspace.name !== FSBL.Clients.WorkspaceClient.activeWorkspace.name &&
 													<div title={deleteTooltip} className={deleteButtonClasses} onMouseDown={this.handleButtonClicks} onClick={
 														allowDelete ? () => { this.deleteWorkspace(workspace.name); } : Function.prototype}><i className="ff-delete"></i></div>}


### PR DESCRIPTION
**Resolves issue [11495](https://chartiq.kanbanize.com/ctrl_board/18/cards/11495/details)**

**Description of change**
-Removed ability to rename active workspace

**Description of testing**
-Attempted to rename current workspace in Preferences. Verified other workspaces could still be named and that it was possible to switch between two workspaces.
