### PR TITLE
11529 resize toolbar vertically

### DIFF
--- a/assets/css/_toolbar.css
+++ b/assets/css/_toolbar.css
@@ -31,6 +31,7 @@
 }
 
 .finsemble-toolbar-section.right {
+		margin-right: 8px;
     justify-content: flex-end;
     order: 2;
     flex: 1;
@@ -76,10 +77,12 @@
     width: 6px;
     max-width: 6px;
     min-width: 6px;
-    background-color: var(--toolbar-resize-area-color);
-    justify-content: flex-end;
+		background-color: var(--toolbar-resize-area-color);
+		position: absolute;
+		right: 0;
+    /* justify-content: flex-end;
     order: 3;
-    flex: 0 0 auto;
+    flex: 0 0 auto; */
 }
 
 @media screen and (max-width: 170px) {


### PR DESCRIPTION
Addresses comments in https://github.com/ChartIQ/finsemble/pull/1065
It also has its own card: https://chartiq.kanbanize.com/ctrl_board/18/cards/11529/details
**Description of change**
-Changed position of `.resize-handle` to `absolute`, with `right: 0` to make it always stay flush with the end of the toolbar.
-Added a slight margin to right section of the toolbar buttons so they retain the original spacing (since `absolute` isn't counted in spacing).

**Description of testing**
- Checked to see that the toolbar still looked normal at various sizes.