### PR TITLE
11486 dockable window animate exception

### DIFF
--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -54,7 +54,7 @@ var Actions = {
 			if (window.outerWidth < 400) {
 				finsembleWindow.getBounds((err, bounds) => {
 					cachedBounds = bounds;
-					finsembleWindow.animate({ transitions: { size: { duration: 150, width: 400 } } }, {}, Function.prototype);
+					finsembleWindow.animate({ transitions: { size: { duration: 150, width: 400 } } }, Function.prototype);
 				})
 			}
 			menuStore.setValue({ field: "active", value: true })
@@ -110,7 +110,7 @@ var Actions = {
 			if (showing) {
 				console.log("close a window")
 				if (!e && cachedBounds) {
-					finsembleWindow.animate({ transitions: { size: { duration: 150, width: cachedBounds.width } } }, {}, () => {
+					finsembleWindow.animate({ transitions: { size: { duration: 150, width: cachedBounds.width } } }, () => {
 						cachedBounds = null;
 					});
 				}


### PR DESCRIPTION
**Resolves issue [11486](https://chartiq.kanbanize.com/ctrl_board/18/cards/11486/details)**

**Description of change**
Using animate function added to DockableWindow. The existing function connected to has fewer parameters.
Requires: https://github.com/ChartIQ/finsemble/pull/1075

**Description of testing**
Make toolbar small and open and close search bar. Verify no exceptions occur.
