### PR TITLE
11624 Disable open fin zoom api

### DIFF
--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -1,3 +1,17 @@
+/*
+	Finsemble Zoom preload, which adds support for: 
+	- Zoom hotkeys (Ctrl +, Ctrl -, Ctrl 0, Ctrl Mousewheel),
+	- A Chrome style popup showing the current zoom level,
+	- Global zoom configuration settings:
+	  - finsemble.Window Manager.zoom.timeout: how long to display the zoom popup for (default 3000ms)
+	  - finsemble.Window Manager.zoom.step: Zoom step size (default 0.1)
+	  - finsemble.Window Manager.zoom.min: Minimum zoom level (default 0.2)
+	  - finsemble.Window Manager.zoom.max Maximum zoom level (default 5)
+	- Zoom level being preserved in window state/workspaces
+
+	N.B. should not be used with OpenFin's window.options.accelerator.zoom option.
+*/
+
 // This global will contain our current zoom level
 window.fsblZoomLevel = 1;
 
@@ -197,11 +211,10 @@ const getZoomLevelHandler = (err, zoomLevel) => {
  * Initializes the zoom handler.
  */
 const runZoomHandler = () => {
-	//ovrrriding openfin zoom function to do nothing
-	var finWindow = fin.desktop.Window.getCurrent();
-	finWindow.setZoomLevel  = function() {
-		//Dont do anything on openfin Zoom
-	}
+	//Override OpenFin zoom function to do nothing 
+	  //which prevents manual use of this function which conflicts with zoom preload
+	  //N.B. window.options.accelerator.zoom setting is not affected by this and will still conflict with Zoom preload if set
+	FSBL.Clients.WindowClient.getCurrentWindow().setZoomLevel = function(level, callback, errorCallback) { callback(); }
 
 	// Insert the zoom pop up, if needed.
 	insertPopUp();

--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -212,7 +212,7 @@ const runZoomHandler = () => {
 	// Create hot keys for zooming.
 	FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "="], zoomIn);
 	//TODO: enable when finsemble supports mapping + key
-	//FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "+"], zoomIn);
+	FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "+"], zoomIn);
 	FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "-"], zoomOut);
 	FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "0"], resetZoom);
 

--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -197,6 +197,12 @@ const getZoomLevelHandler = (err, zoomLevel) => {
  * Initializes the zoom handler.
  */
 const runZoomHandler = () => {
+	//ovrrriding openfin zoom function to do nothing
+	var finWindow = fin.desktop.Window.getCurrent();
+	finWindow.setZoomLevel  = function() {
+		//Dont do anything on openfin Zoom
+	}
+
 	// Insert the zoom pop up, if needed.
 	insertPopUp();
 


### PR DESCRIPTION
**Resolves issue [11624](https://chartiq.kanbanize.com/ctrl_board/18/cards/11624/details)**

**Description of change**
-Override OpenFin setZoomLevel function in setup of our preload - reintroduced from old zoom preload in use at JPM
-Added mapping for numeric keypad + key

**Description of testing**
-Tested zooming with Wlecome component was unaffected by change