### PR TITLE
11550 toolbarhotkey

### DIFF
--- a/src-built-in/components/searchMenu/src/app.jsx
+++ b/src-built-in/components/searchMenu/src/app.jsx
@@ -69,7 +69,7 @@ class SearchMenu extends React.Component {
 			self.setState({
 				newList: true,
 				pref: false,
-				listChanged: true,
+				textEmpty: data.value.textEmpty,
 				componentList: data.value || []
 			}, () => {
 				if (FTD) self.fitToDOM();
@@ -126,8 +126,8 @@ class SearchMenu extends React.Component {
 		var bestMatch = this.getBestMatch();//We need to find this ahead of time so that we don't render the best match in multiple locations
 		var totalElements = 0;// So we can decide if we want to use best match
 		var componentIndex = -1;
-		var listChanged = false;
-		listChanged = this.state.listChanged;
+		const textEmpty = (typeof this.state.textEmpty !== 'undefined') ? this.state.textEmpty : true;
+		window.localStorage.setItem('textEmpty', textEmpty);
 		this.state.componentList.map(function (providerInfo, providerIndex) {
 			if (!providerInfo.data.length) return;
 
@@ -162,7 +162,10 @@ class SearchMenu extends React.Component {
 				</ProviderList >
 			)
 		})
-		if (!listElements.length && listChanged) return <div className="no-results"> No Results Found</div>
+		//if (textEmpty)	return null;
+		if (!listElements.length) {
+			return <div className="no-results"> No Results Found</div>;
+		}
 		return <div >
 			{(totalElements >= 1 ? <div><div className="bestMatch searchHeader">Best Match</div>
 				<div>{(bestMatch ? bestMatch.component : null)}</div></div> : null)}

--- a/src-built-in/components/searchMenu/src/app.jsx
+++ b/src-built-in/components/searchMenu/src/app.jsx
@@ -159,10 +159,7 @@ class SearchMenu extends React.Component {
 				</ProviderList >
 			)
 		})
-		//if (textEmpty)	return null;
-		if (!listElements.length) {
-			return <div className="no-results"> No Results Found</div>;
-		}
+		if (!listElements.length) return <div className="no-results"> No Results Found</div>
 		return <div >
 			{(totalElements >= 1 ? <div><div className="bestMatch searchHeader">Best Match</div>
 				<div>{(bestMatch ? bestMatch.component : null)}</div></div> : null)}

--- a/src-built-in/components/searchMenu/src/app.jsx
+++ b/src-built-in/components/searchMenu/src/app.jsx
@@ -69,7 +69,6 @@ class SearchMenu extends React.Component {
 			self.setState({
 				newList: true,
 				pref: false,
-				textEmpty: data.value.textEmpty,
 				componentList: data.value || []
 			}, () => {
 				if (FTD) self.fitToDOM();
@@ -126,8 +125,6 @@ class SearchMenu extends React.Component {
 		var bestMatch = this.getBestMatch();//We need to find this ahead of time so that we don't render the best match in multiple locations
 		var totalElements = 0;// So we can decide if we want to use best match
 		var componentIndex = -1;
-		const textEmpty = (typeof this.state.textEmpty !== 'undefined') ? this.state.textEmpty : true;
-		window.localStorage.setItem('textEmpty', textEmpty);
 		this.state.componentList.map(function (providerInfo, providerIndex) {
 			if (!providerInfo.data.length) return;
 

--- a/src-built-in/components/searchMenu/src/app.jsx
+++ b/src-built-in/components/searchMenu/src/app.jsx
@@ -69,6 +69,7 @@ class SearchMenu extends React.Component {
 			self.setState({
 				newList: true,
 				pref: false,
+				listChanged: true,
 				componentList: data.value || []
 			}, () => {
 				if (FTD) self.fitToDOM();
@@ -125,6 +126,8 @@ class SearchMenu extends React.Component {
 		var bestMatch = this.getBestMatch();//We need to find this ahead of time so that we don't render the best match in multiple locations
 		var totalElements = 0;// So we can decide if we want to use best match
 		var componentIndex = -1;
+		var listChanged = false;
+		listChanged = this.state.listChanged;
 		this.state.componentList.map(function (providerInfo, providerIndex) {
 			if (!providerInfo.data.length) return;
 
@@ -159,7 +162,7 @@ class SearchMenu extends React.Component {
 				</ProviderList >
 			)
 		})
-		if (!listElements.length) return <div className="no-results"> No Results Found</div>
+		if (!listElements.length && listChanged) return <div className="no-results"> No Results Found</div>
 		return <div >
 			{(totalElements >= 1 ? <div><div className="bestMatch searchHeader">Best Match</div>
 				<div>{(bestMatch ? bestMatch.component : null)}</div></div> : null)}

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -109,7 +109,6 @@ export default class Search extends React.Component {
 		this.setState({ active: true, hotketSet: true })
 	}
 	focused(e) {
-		console.log("in focused");
 		function selectElementContents(el) {
 			var range = document.createRange();
 			range.selectNodeContents(el);
@@ -133,7 +132,6 @@ export default class Search extends React.Component {
 		}, 100);
 	}
 	blurred() {
-		console.log("in blurred");
 		//this.setState({ focus: false, saveText: document.getElementById("searchInput").textContent });
 		//document.getElementById("searchInput").innerHTML = ""; // Don't clear out the old search text
 		storeExports.Actions.setFocus(false)

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -109,6 +109,7 @@ export default class Search extends React.Component {
 		this.setState({ active: true, hotketSet: true })
 	}
 	focused(e) {
+		console.log("in focused");
 		function selectElementContents(el) {
 			var range = document.createRange();
 			range.selectNodeContents(el);
@@ -132,6 +133,7 @@ export default class Search extends React.Component {
 		}, 100);
 	}
 	blurred() {
+		console.log("in blurred");
 		//this.setState({ focus: false, saveText: document.getElementById("searchInput").textContent });
 		//document.getElementById("searchInput").innerHTML = ""; // Don't clear out the old search text
 		storeExports.Actions.setFocus(false)

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -20,7 +20,8 @@ export default class Search extends React.Component {
 
 		// Handler for obtaining the search inputContainer bounds for the location of the
 		// search results popup, which is displayed by the SearchStore.
-		SearchStore.setInputContainerBoundsHandler(this.getInputContainerBounds.bind(this))
+		SearchStore.setInputContainerBoundsHandler(this.getInputContainerBounds.bind(this));
+		SearchStore.setBlurSearchInputHandler(this.blurSearchInput.bind(this));
 	}
 	/**
 	 * Returns getBoundingClientRect of the inputContainer div element for positioning search results
@@ -31,6 +32,9 @@ export default class Search extends React.Component {
 			return inputContainer.getBoundingClientRect();
 		}
 		return undefined;
+	}
+	blurSearchInput() {
+		document.getElementById("searchInput").blur();
 	}
 	onStateUpdate(err, data) {
 		//this.setState({ focus: data.value, saveText: document.getElementById("searchInput").textContent })

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -3,6 +3,7 @@ import { FinsembleButton, FinsembleToolbarSeparator } from "@chartiq/finsemble-r
 import * as storeExports from "../stores/searchStore";
 import * as _debounce from "lodash.debounce"
 import ToolbarStore from "../stores/toolbarStore";
+import {Actions as SearchStore} from "../stores/searchStore";
 
 let menuStore;
 export default class Search extends React.Component {
@@ -16,6 +17,17 @@ export default class Search extends React.Component {
 		};
 		this.bindCorrectContext();
 		let self = this;
+
+		// Handler for obtaining the search inputContainer bounds for the location of the
+		// search results popup, which is displayed by the SearchStore.
+		SearchStore.getInputContainerBounds = this.getInputContainerBounds.bind(this);
+	}
+	getInputContainerBounds(){
+		const inputContainer = document.getElementById("inputContainer");
+		if (inputContainer) {
+			return inputContainer.getBoundingClientRect();
+		}
+		return undefined;
 	}
 	onStateUpdate(err, data) {
 		//this.setState({ focus: data.value, saveText: document.getElementById("searchInput").textContent })

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -20,9 +20,12 @@ export default class Search extends React.Component {
 
 		// Handler for obtaining the search inputContainer bounds for the location of the
 		// search results popup, which is displayed by the SearchStore.
-		SearchStore.getInputContainerBounds = this.getInputContainerBounds.bind(this);
+		SearchStore.setInputContainerBoundsHandler(this.getInputContainerBounds.bind(this))
 	}
-	getInputContainerBounds(){
+	/**
+	 * Returns getBoundingClientRect of the inputContainer div element for positioning search results
+	 */
+	getInputContainerBounds() {
 		const inputContainer = document.getElementById("inputContainer");
 		if (inputContainer) {
 			return inputContainer.getBoundingClientRect();

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -87,28 +87,33 @@ var Actions = {
 	},
 
 	/**
+	 * Event handler for determining bounds for the search input container div
+	 */
+	getInputContainerBounds : Function.prototype,
+
+	/**
 	 * Positions a dropdown window under the search bar containing the search results.
 	 * Returns immediately if the text is empty so a search results menu doesn't appear
 	 */
 	positionSearchResults() {
-		let text = document.getElementById("searchInput").innerHTML;
-		if (!text) return;
-		const inputContainer = document.getElementById("inputContainer");
-		if (inputContainer) {
-			const bounds = inputContainer.getBoundingClientRect();
-			let showParams = {
-				monitor: 'mine',
-				position: 'relative',
-				left: bounds.left,
-				forceOntoMonitor: true,
-				top: 'adjacent',
-				autoFocus: false
-			}
-			FSBL.Clients.LauncherClient.showWindow({ windowName: menuWindow.name }, showParams);
 
-		} else {
-			FSBL.Clients.Logger.error("No element with ID 'inputContainer' exists");
+		const bounds = this.getInputContainerBounds();
+
+		if(!bounds || !bounds.left) {
+			FSBL.Clients.Logger.error("No bounds received from getInputContainerBounds.  Assuming {left: 0}.")
+			bounds = {left:0};
 		}
+
+		let showParams = {
+			monitor: 'mine',
+			position: 'relative',
+			left: bounds.left,
+			forceOntoMonitor: true,
+			top: 'adjacent',
+			autoFocus: false
+		}
+		FSBL.Clients.LauncherClient.showWindow({ windowName: menuWindow.name }, showParams);
+
 	},
 	
 	/**

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -68,7 +68,10 @@ var Actions = {
 			return menuWindow.isShowing((err, showing) => {
 				if (showing) return;
 
-				Actions.positionSearchResults();
+				var textEmpty = JSON.parse(window.localStorage.getItem('textEmpty'));
+				if (!textEmpty)
+					Actions.positionSearchResults();
+				
 			});
 
 		}
@@ -86,6 +89,11 @@ var Actions = {
 			})
 		})
 	},
+
+	/**
+	 * Positions a dropdown window under the search bar containing the search results.
+	 *
+	 */
 	positionSearchResults() {
 		const inputContainer = document.getElementById("inputContainer");
 		if (inputContainer) {
@@ -104,7 +112,13 @@ var Actions = {
 			FSBL.Clients.Logger.error("No element with ID 'inputContainer' exists");
 		}
 	},
-	//handleClose gets called for several reasons. One of those is when the window starts moving. If it starts moving, an event is passed in. If the event is passed in, we don't want to animate the window. If it's just a blur, we'll animate the change in size.
+	
+	/**
+	 * handleClose gets called for several reasons. One of those is when the window starts moving. 
+	 * If it starts moving, an event is passed in. If the event is passed in, we don't want to animate the window.
+	 *  If it's just a blur, we'll animate the change in size.
+	 * @param {*} e
+	 */
 	handleClose(e) {
 		menuWindow.isShowing(function (err, showing) {
 			if (showing) {
@@ -120,6 +134,7 @@ var Actions = {
 				if (!menuWindow) return;
 				menuWindow.hide();
 			}
+			menuStore.setValue({ field: "active", value: false })
 		});
 
 	},
@@ -152,10 +167,24 @@ var Actions = {
 			Actions.setupWindow()
 		}
 	},
+
+	/**
+	 * Perform the search action
+	 * If there is no search text, don't show any results
+	 * @param {*} text
+	 * @returns
+	 */
 	search(text) {
-		if (text === "" || !text) return Actions.setList([]);
+		var updatedResults;
+		if (text === "" || !text) {
+			updatedResults =[];
+			updatedResults.textEmpty = true;
+			Actions.setList(updatedResults);
+			return menuWindow.hide();
+		}
 		FSBL.Clients.SearchClient.search({ text: text }, function (err, response) {
-			var updatedResults = [].concat.apply([], response)
+			updatedResults = [].concat.apply([], response)
+			updatedResults.textEmpty = false;
 			Actions.setList(updatedResults);
 			setTimeout(() => {
 				Actions.positionSearchResults();

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -15,6 +15,9 @@ var control = null;
 // Handler for determing where to show the search results component.  Currently being set by the search input in Search.jsx
 var inputContainerBoundsHandler = Function.prototype;
 
+// Handler for bluring the search input.  Currently being set and used in Search.jsx
+var blurSearchInputHandler = Function.prototype;
+
 function mouseInElement(element, cb) {
 	var elementBounds = element.getBoundingClientRect();
 	window.screenX;
@@ -90,13 +93,13 @@ var Actions = {
 	/**
 	 * Assign a function to retrieve the location where the search results should be displayed.
 	 *
-	 * @param {Function} inputContainerBoundsHandler
+	 * @param {Function} boundsHandler
 	 */
-	setInputContainerBoundsHandler(inputContainerBoundsHandler) {
-		if (typeof inputContainerBoundsHandler !== 'function') {
-			FSBL.Clients.Logger.error("Parameter inputContainerBoundsHandler must be a function.")
+	setInputContainerBoundsHandler(boundsHandler) {
+		if (typeof boundsHandler !== 'function') {
+			FSBL.Clients.Logger.error("Parameter boundsHandler must be a function.")
 		} else {
-			this.inputContainerBoundsHandler = inputContainerBoundsHandler;
+			inputContainerBoundsHandler = boundsHandler;
 		}
 	},
 
@@ -107,7 +110,7 @@ var Actions = {
 	positionSearchResults() {
 
 		// Call function to retrieve location to display search results
-		const bounds = this.inputContainerBoundsHandler();
+		const bounds = inputContainerBoundsHandler();
 
 		if (!bounds || !bounds.left) {
 			FSBL.Clients.Logger.error("No bounds received from inputContainerBoundsHandler.  Assuming {left: 0}.")
@@ -124,6 +127,20 @@ var Actions = {
 		}
 		FSBL.Clients.LauncherClient.showWindow({ windowName: menuWindow.name }, showParams);
 
+	},
+
+
+	/**
+	 * Assign a function to blur the search input DOM element.
+	 *
+	 * @param {Function} blurHandler
+	 */
+	setBlurSearchInputHandler(blurHandler) {
+		if(typeof blurHandler !== 'function'){
+			FSBL.Clients.Logger.error("Parameter blurHandler must be a function.");
+		} else {
+			blurSearchInputHandler = blurHandler;
+		}
 	},
 	
 	/**
@@ -147,7 +164,7 @@ var Actions = {
 			}
 			//These lines handle closing the searchInput box. As showing is only true when the search results
 			//menu opens, they need to be outside so the search inputbox will still close when there is no text string.
-			document.getElementById("searchInput").blur();
+			blurSearchInputHandler();
 			menuStore.setValue({ field: "active", value: false })		
 		});
 	
@@ -179,6 +196,14 @@ var Actions = {
 		menuReference = data.value;
 		if (!menuWindow) {
 			Actions.setupWindow()
+		}
+	},
+
+	setBlurSearchInputHandler(blurHandler) {
+		if(typeof blurHandler !== 'function'){
+			FSBL.Clients.Logger.error("Parameter blurHandler must be a function.");
+		} else {
+			blurSearchInputHandler = blurHandler;
 		}
 	},
 

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -12,7 +12,8 @@ var menuReference = {};
 var menuWindow = null;
 var control = null;
 
-
+// Handler for determing where to show the search results component.  Currently being set by the search input in Search.jsx
+var inputContainerBoundsHandler = Function.prototype;
 
 function mouseInElement(element, cb) {
 	var elementBounds = element.getBoundingClientRect();
@@ -87,9 +88,17 @@ var Actions = {
 	},
 
 	/**
-	 * Event handler for determining bounds for the search input container div
+	 * Assign a function to retrieve the location where the search results should be displayed.
+	 *
+	 * @param {Function} inputContainerBoundsHandler
 	 */
-	getInputContainerBounds : Function.prototype,
+	setInputContainerBoundsHandler(inputContainerBoundsHandler) {
+		if (typeof inputContainerBoundsHandler !== 'function') {
+			FSBL.Clients.Logger.error("Parameter inputContainerBoundsHandler must be a function.")
+		} else {
+			this.inputContainerBoundsHandler = inputContainerBoundsHandler;
+		}
+	},
 
 	/**
 	 * Positions a dropdown window under the search bar containing the search results.
@@ -97,11 +106,12 @@ var Actions = {
 	 */
 	positionSearchResults() {
 
-		const bounds = this.getInputContainerBounds();
+		// Call function to retrieve location to display search results
+		const bounds = this.inputContainerBoundsHandler();
 
-		if(!bounds || !bounds.left) {
-			FSBL.Clients.Logger.error("No bounds received from getInputContainerBounds.  Assuming {left: 0}.")
-			bounds = {left:0};
+		if (!bounds || !bounds.left) {
+			FSBL.Clients.Logger.error("No bounds received from inputContainerBoundsHandler.  Assuming {left: 0}.")
+			bounds = { left: 0 };
 		}
 
 		let showParams = {

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -130,8 +130,8 @@ var Actions = {
 				if (!menuWindow) return;			
 				menuWindow.hide();
 			}
-			//These lines handle closing the searchInput box. This needs to happen outside the isShowing show
-			// the search field will still close when there is no text string.
+			//These lines handle closing the searchInput box. As showing is only true when the search results
+			//menu opens, they need to be outside so the search inputbox will still close when there is no text string.
 			document.getElementById("searchInput").blur();
 			menuStore.setValue({ field: "active", value: false })		
 		});

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -13,6 +13,7 @@ var menuWindow = null;
 var control = null;
 
 
+
 function mouseInElement(element, cb) {
 	var elementBounds = element.getBoundingClientRect();
 	window.screenX;
@@ -77,6 +78,7 @@ var Actions = {
 		menuWindow.isShowing(function (err, showing) {
 			//if (!showing) return//console.log("not showing")
 			mouseInWindow(menuWindow, function (err, inBounds) {
+
 				if (!inBounds) {
 					Actions.handleClose();
 				}
@@ -118,6 +120,7 @@ var Actions = {
 	handleClose(e) {
 		menuWindow.isShowing(function (err, showing) {
 			if (showing) {
+				console.log("close a window")
 				if (!e && cachedBounds) {
 					finsembleWindow.animate({ transitions: { size: { duration: 150, width: cachedBounds.width } } }, {}, () => {
 						cachedBounds = null;
@@ -132,7 +135,7 @@ var Actions = {
 			document.getElementById("searchInput").blur();
 			menuStore.setValue({ field: "active", value: false })		
 		});
-		
+	
 	},
 
 	setupWindow(cb = Function.prototype) {
@@ -171,13 +174,12 @@ var Actions = {
 	 * @returns
 	 */
 	search(text) {
-		var updatedResults;
 		if (text === "" || !text) {
 			Actions.setList([]);
 			return menuWindow.hide();
 		}
 		FSBL.Clients.SearchClient.search({ text: text }, function (err, response) {
-			updatedResults = [].concat.apply([], response)
+			var updatedResults = [].concat.apply([], response)
 			Actions.setList(updatedResults);
 			setTimeout(() => {
 				Actions.positionSearchResults();
@@ -190,8 +192,7 @@ var Actions = {
 				Actions.handleClose();
 			}
 		})
-	},
-
+	}
 };
 function searchTest(params, cb) {
 	//console.log("params", params)
@@ -224,7 +225,6 @@ function createStore(done) {
 				if (action.actionType === "menuBlur") {
 					Actions.menuBlur();
 				} else if (action.actionType === "clear") {
-					//console.log("createStore.getValues, clear action: handleClose");
 					Actions.handleClose();
 				}
 			});
@@ -250,7 +250,6 @@ function createStore(done) {
 	finsembleWindow.listenForBoundsSet();
 	finsembleWindow.addListener("startedMoving", Actions.handleClose);
 	finsembleWindow.addListener("blurred", function (event) {
-		//console.log("Window blurred event fired");
 		Actions.setFocus(false);
 	}, function () {
 	}, function (reason) {

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -4,6 +4,7 @@
 */
 import async from "async";
 import * as menuConfig from '../config.json';
+import * as storeExports from "../stores/searchStore";
 
 import { Actions as SearchActions } from "./searchStore"
 
@@ -199,6 +200,7 @@ class _ToolbarStore {
 
 	/**
 	 * Function to bring toolbar to front (since dockable toolbar can be hidden)
+	 * The search input box will be open and any previous results will be displayed
 	 * @param {boolean} focus If true, will also focus the toolbar
 	 * @memberof _ToolbarStore
 	 */
@@ -208,6 +210,7 @@ class _ToolbarStore {
 			if (focus) {
 				finsembleWindow.focus();
 				self.Store.setValue({ field: "searchActive", value: false });
+				storeExports.Actions.positionSearchResults();				
 			}
 		});
 	}


### PR DESCRIPTION
**Resolves issue [11550](https://chartiq.kanbanize.com/ctrl_board/18/cards/11550/details)**

**Description of change**
-Removed display of Search Results when there are no previous search results and when a search string is deleted.
-Fixed toolbar hotkey to bring along search results dropdown to toolbar's new location.

**Description of testing**
-Tested search input box with and without values. Tested moving the toolbar around the screen and near the edge of monitors using ctrl+alt+t, both with the searchbar open and closed.
