### PR TITLE
e2o should point to a specific release

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "license": "",
     "optionalDependencies": {
         "openfin-launcher": "^1.3.11",
-        "@chartiq/e2o": "latest"
+        "@chartiq/e2o": "3.7.*"
     },
     "dependencies": {
         "@chartiq/finsemble": "3.7.*",


### PR DESCRIPTION
**Resolves issue [11664](https://chartiq.kanbanize.com/ctrl_board/18/cards/11664/details)**

**Description of change**
- Point to e2o 3.7.0 instead of latest.

**Description of testing**
- Built and ran Finsemble on Electron