### PR TITLE
Use process.env for environment in e2o

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -392,7 +392,8 @@
 			logToTerminal(command);
 			electronProcess = exec(command,
 				{
-					cwd: e2oLocation
+					cwd: e2oLocation,
+					env: process.env,
 				}, function (err) {
 					logToTerminal(err);
 					logToTerminal("e2o not installed? Try `npm install`", "red");


### PR DESCRIPTION
**Resolves issue [11693](https://chartiq.kanbanize.com/ctrl_board/18/cards/11693/details)**

**Description of change**
Use `process.env` as default env for e2o when launching.

**Description of testing**
Ensure process.env is passed to e2o on startup.
