### PR TITLE
11939 Added e2o version check

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -268,12 +268,16 @@
 			const CLI_VERSION = require(path.join(CLI_PATH, "package.json")).version;
 			const CONTROLS_PATH = path.join(__dirname, "node_modules", "@chartiq", "finsemble-react-controls");
 			const CONTROLS_VERSION = require(path.join(CONTROLS_PATH, "package.json")).version;
+			
+			// Check e2o version
 			const E2O_PATH = path.join(__dirname, "node_modules", "@chartiq", "e2o");
-			const E2O_VERSION = channelAdapter === "e2o" && fs.existsSync(E2O_PATH) ? require(path.join(E2O_PATH, "package.json")).version : undefined ;
-
-			if (channelAdapter === "e2o" && !fs.existsSync(E2O_PATH)) {
+			const E2O_PATH_EXISTS = fs.existsSync(E2O_PATH);
+			const USING_E2O = channelAdapter === "e2o";
+			if (USING_E2O && !E2O_PATH_EXISTS) {
 				throw "Cannot use e2o channelAdapter unless e2o optional dependency is installed. Please run npm i @chartiq/e2o";
 			}
+
+			const E2O_VERSION = require(path.join(E2O_PATH, "package.json")).version;
 
 			function checkLink(params, cb) {
 				let { path, name, version } = params;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -271,6 +271,10 @@
 			const E2O_PATH = path.join(__dirname, "node_modules", "@chartiq", "e2o");
 			const E2O_VERSION = channelAdapter === "e2o" && fs.existsSync(E2O_PATH) ? require(path.join(E2O_PATH, "package.json")).version : undefined ;
 
+			if (channelAdapter === "e2o" && !fs.existsSync(E2O_PATH)) {
+				throw "Cannot use e2o channelAdapter unless e2o optional dependency is installed. Please run npm i @chartiq/e2o";
+			}
+
 			function checkLink(params, cb) {
 				let { path, name, version } = params;
 				if (fs.existsSync(path)) {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -268,6 +268,8 @@
 			const CLI_VERSION = require(path.join(CLI_PATH, "package.json")).version;
 			const CONTROLS_PATH = path.join(__dirname, "node_modules", "@chartiq", "finsemble-react-controls");
 			const CONTROLS_VERSION = require(path.join(CONTROLS_PATH, "package.json")).version;
+			const E2O_PATH = path.join(__dirname, "node_modules", "@chartiq", "e2o");
+			const E2O_VERSION = channelAdapter === "e2o" && fs.existsSync(E2O_PATH) ? require(path.join(E2O_PATH, "package.json")).version : undefined ;
 
 			function checkLink(params, cb) {
 				let { path, name, version } = params;
@@ -307,6 +309,18 @@
 						version: CONTROLS_VERSION
 					}, cb)
 				},
+				(cb) => {
+					if (!E2O_VERSION) {
+						// e2o not found so skip check
+						return cb();
+					}
+
+					checkLink({
+						path: E2O_PATH,
+						name: "e2o",
+						version: E2O_VERSION
+					}, cb)
+				}
 			], done)
 		},
 


### PR DESCRIPTION
**Resolves issue [11939](https://chartiq.kanbanize.com/ctrl_board/18/cards/11939/details)**

**Description of change**
- Added print of e2o version if `channelAdapter` is `e2o` and e2o is installed

**Description of testing**
- Clean checkout and install
- Run `npm run build` - builds successfully, no e2o output
- Change `channelAdapter` in `config/other/server-environment-startup.json` to `e2o`
- run `npm run build` - Throws error, suggests installing e2o
- Run `npm i @chartiq/e2o`
- Run `npm run build` - Builds successfully, output e2o version
- Change `channelAdapter` in `config/other/server-environment-startup.json` to `openfin`
- run `npm run build` - builds successfully, does not output e2o version