### PR TITLE
11567 listen for DOM resize event to resize the tabs.

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -8,6 +8,8 @@ import { FinsembleHoverDetector } from "@chartiq/finsemble-react-controls";
 import { FinsembleDnDContext, FinsembleDroppable } from '@chartiq/finsemble-react-controls';
 import { Store, Actions } from "../../stores/windowTitleBarStore";
 import Title from "../../../../common/windowTitle";
+import * as _throttle from "lodash.throttle";
+
 const PLACEHOLDER_TAB = {
     windowName: "",
     uuid: "",
@@ -18,7 +20,6 @@ let TAB_WIDTH = 300;
 const ICON_AREA = 29;
 const CLOSE_BUTTON_MARGIN = 22;
 const MINIMUM_TAB_SIZE = 100;
-import * as _throttle from "lodash.throttle";
 export default class TabRegion extends React.Component {
     constructor(props) {
         super(props);

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -18,7 +18,7 @@ let TAB_WIDTH = 300;
 const ICON_AREA = 29;
 const CLOSE_BUTTON_MARGIN = 22;
 const MINIMUM_TAB_SIZE = 100;
-
+import * as _throttle from "lodash.throttle";
 export default class TabRegion extends React.Component {
     constructor(props) {
         super(props);
@@ -61,6 +61,7 @@ export default class TabRegion extends React.Component {
         this.onTabDraggedOver = this.onTabDraggedOver.bind(this);
         this.isTabRegionOverflowing = this.isTabRegionOverflowing.bind(this);
         this.onWindowResize = this.onWindowResize.bind(this);
+        this.onWindowResizeThrottled = _throttle(this.onWindowResize, 100);
         this.getTabWidth = this.getTabWidth.bind(this);
         this.setTabListTranslateX = this.setTabListTranslateX.bind(this);
         this.onTabListTranslateChanged = this.onTabListTranslateChanged.bind(this);
@@ -84,8 +85,8 @@ export default class TabRegion extends React.Component {
         return newTabWidth < MINIMUM_TAB_SIZE ? MINIMUM_TAB_SIZE : newTabWidth;
     }
     /**
- * Resize handler. Calculates the space that the center-region is taking up. May be used to scale tabs proportionally.
- */
+     * Resize handler. Calculates the space that the center-region is taking up. May be used to scale tabs proportionally.
+     */
     onWindowResize() {
         let bounds = this.refs.Me.getBoundingClientRect();
         this.setState({
@@ -463,7 +464,7 @@ export default class TabRegion extends React.Component {
     }
 
     componentDidMount() {
-        FSBL.Clients.WindowClient.finsembleWindow.addListener('bounds-set', this.onWindowResize);
+        window.addEventListener("resize", this.onWindowResizeThrottled);
         let boundingBox = this.refs.Me.getBoundingClientRect();
         this.setState({
             boundingBox: boundingBox,
@@ -475,7 +476,7 @@ export default class TabRegion extends React.Component {
         // Store.removeListener({ field: "activeTab" }, this.onActiveTabChanged);
         Store.removeListener({ field: "tabs" }, this.onTabsChanged);
         Store.removeListener({ field: "tabListTranslateX" }, this.onTabListTranslateChanged)
-        FSBL.Clients.WindowClient.finsembleWindow.removeListener('bounds-set', this.onWindowResize);
+        window.removeEventListener("resize", this.onWindowResizeThrottled);
 
     }
     hoverAction(newHoverState) {


### PR DESCRIPTION
**Resolves issue [11567](https://chartiq.kanbanize.com/ctrl_board/18/cards/11567/details)**

**Description of change**
-Previously we listened for bounds-set events on the finsemble windows.
-Moves to listening on the DOM's resize event.

This works because of the way the underlying container's events are abstracted away from the DOM. Even though the outer rectangle has been resized and an event has been received, the DOM may not have redrawn itself. Because tab sizing depends on the physical pixel size of the items in the DOM, this PR changes the listener from the finsemble window to the DOM window.

**Description of testing**
-Restored/maximized/resized a couple of stacks of various sizes.
