### PR TITLE
11878 workspace dialogs

### DIFF
--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -215,7 +215,8 @@ Actions = {
 		let dialogParams = {
 			title: "Delete this workspace?",
 			question: "Are you sure you want to delete the workspace \"" + workspaceName + "\"?",
-			showCancelButton: false,
+			showNegativeButton: false,
+			affirmativeResponseLabel: "Delete",
 			hideModalOnClose: data.hideModalOnClose
 		};
 

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -561,8 +561,8 @@ Actions = {
 		let dialogParams = {
 			title: "Overwrite Workspace?",
 			question: "This will overwrite the saved data for  \"" + workspaceName + "\". Would you like to proceed?",
-			affirmativeResponseLabel: "Yes, overwrite",
-			showCancelButton: false
+			affirmativeResponseLabel: "Overwrite",
+			showNegativeButton: false
 		};
 		function onUserInput(err, response) {
 			if (response.choice === "affirmative") {

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -501,7 +501,9 @@ Actions = {
 			Logger.system.log("NewWorkspace.spawnDialog start.");
 			let dialogParams = {
 				title: "Save your workspace?",
-				question: `Your workspace "${activeWorkspace.name}" has unsaved changes. Would you like to save?`
+				question: `Your workspace "${activeWorkspace.name}" has unsaved changes. Would you like to save?`,
+				affirmativeResponseLabel: "Save",
+				negativeResponseLabel: "Don't Save"
 			};
 			function onUserInput(err, response) {
 				Logger.system.log("Spawn Dialog callback.");


### PR DESCRIPTION
**Resolves issue [11878](https://chartiq.kanbanize.com/ctrl_board/18/cards/11878/details)**

**Description of change**
- Adjusted workspace dialog buttons so they reflect the actions that will be performed. (It's better UX than labeling them "Yes" or "No".)

**Description of testing**
1.  Dirty a workspace and perform a workspace switch. Check to see that saving dialog buttons read "Don't Save | Cancel | Save"

2. Choose "Save As" and name a workspace the same as another workspace. The prompting dialog's buttons should read "Cancel | Overwrite"

3. When deleting a workspace, the prompting dialog's buttons should read "Cancel | Delete"
