### PR TITLE
Don't adjust body margin-top in titlebar implementation, let windowCl…

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBar.jsx
@@ -56,6 +56,7 @@ class WindowTitleBar extends React.Component {
 			this.toolbarRight = element;
 		}
 
+
 		this.bindCorrectContext();
 		windowTitleBarStore.getValue({ field: "Maximize.hide" });
 		this.dragEndTimeout = null;
@@ -127,8 +128,6 @@ class WindowTitleBar extends React.Component {
 
 	componentDidMount() {
 		let header = document.getElementsByClassName("fsbl-header")[0];
-		let headerHeight = window.getComputedStyle(header, null).getPropertyValue("height");
-		document.body.style.marginTop = headerHeight;
 		this.resizeDragHandle();
 		this.hackScrollbar();
 	}


### PR DESCRIPTION
**Resolves issue [11971](https://chartiq.kanbanize.com/ctrl_board/18/cards/11971/details)**

**Description of change**
-Removed management of body tag's margin-top (windowClient already does this)

**Description of testing**
-Change `FSBLHeader: true` in a component config to `FSBLHeader: {"bodyMarginTop": "200px"}`  and `FSBLHeader: {"bodyMarginTop": "auto"}` and review behaviour.
