### PR TITLE
11967 dialog buttons

### DIFF
--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -263,6 +263,8 @@ var Actions = {
 		FSBL.Clients.DialogManager.open("yesNo", {
 			title: "Delete this App?",
 			question: "Are you sure you would like to delete \"" + componentName + "\"?",
+			affirmativeResponseLabel: "Delete",
+			showNegativeButton: false
 		}, function (err, response) {
 			// If the user chooses "affirmative" then delete the component.
 			// We should never get an error, but if we do then go ahead and delete the component too.

--- a/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
+++ b/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
@@ -292,7 +292,7 @@ var Actions = {
 		FSBL.Clients.DialogManager.open("yesNo", {
 			title: "Terminate Process?",
 			question: "Terminating the process may close other apps. Are you sure you want to continue?",
-			affirmativeButtonLabel: "Terminate",
+			affirmativeResponseLabel: "Terminate",
 			showNegativeButton: false
 		}, (err, response) => {
 			if (err || response.choice === "affirmative") {
@@ -341,7 +341,7 @@ var Actions = {
 				FSBL.Clients.DialogManager.open("yesNo", {
 					title: "Terminate Process?",
 					question: "The app that you are attempting to close is unresponsive. Would you like to terminate the process? Terminating the process may close other apps.",
-					affirmativeButtonLabel:"Terminate",
+					affirmativeResponseLabel:"Terminate",
 					showNegativeButton: false
 				}, (err, response) => {
 					if (err || response.choice === "affirmative") {

--- a/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
+++ b/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
@@ -292,8 +292,8 @@ var Actions = {
 		FSBL.Clients.DialogManager.open("yesNo", {
 			title: "Terminate Process?",
 			question: "Terminating the process may close other apps. Are you sure you want to continue?",
-			showCancelButton: false,
-			showNegativeButton: true
+			affirmativeButtonLabel: "Terminate",
+			showNegativeButton: false
 		}, (err, response) => {
 			if (err || response.choice === "affirmative") {
 				politeCloseProcess();
@@ -341,8 +341,8 @@ var Actions = {
 				FSBL.Clients.DialogManager.open("yesNo", {
 					title: "Terminate Process?",
 					question: "The app that you are attempting to close is unresponsive. Would you like to terminate the process? Terminating the process may close other apps.",
-					showCancelButton: false,
-					showNegativeButton: true
+					affirmativeButtonLabel:"Terminate",
+					showNegativeButton: false
 				}, (err, response) => {
 					if (err || response.choice === "affirmative") {
 						return Actions.terminateProcess(parentApp, true)

--- a/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
+++ b/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
@@ -341,7 +341,7 @@ var Actions = {
 				FSBL.Clients.DialogManager.open("yesNo", {
 					title: "Terminate Process?",
 					question: "The app that you are attempting to close is unresponsive. Would you like to terminate the process? Terminating the process may close other apps.",
-					affirmativeResponseLabel:"Terminate",
+					affirmativeResponseLabel: "Terminate",
 					showNegativeButton: false
 				}, (err, response) => {
 					if (err || response.choice === "affirmative") {


### PR DESCRIPTION
**Resolves issue [11967](https://chartiq.kanbanize.com/ctrl_board/18/cards/11967/details)**

**Description of change**
- Altered the dialog buttons for the Terminate Process, Delete App

**Description of testing**
-Open the Process Monitor and press "Terminate" next to one of the processes. The dialog that appears should have the options "Cancel" and "Terminate"
- Create an adhoc component, then go to the menu and delete it. The dialog that appears should have the options  "Cancel" and "Delete"
