### PR TITLE
Fix Maximize Toolbar loop

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -533,7 +533,8 @@
 				"category": "system",
 				"spawnOnStartup": true,
 				"spawnOnAllMonitors": false,
-				"canMinimize": false
+				"canMinimize": false,
+				"canMaximize": false
 			},
 			"foreign": {
 				"services": {

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -181,11 +181,7 @@ class _ToolbarStore {
 				value: bounds
 			}, Function.prototype);
 		}
-		let restoreWindow = (e) => {
-			finsembleWindow.restore();
-		}
-		//Immediately restore on maximize.
-		finsembleWindow.addListener("maximized", restoreWindow);
+		
 		finsembleWindow.addListener("bounds-change-end", onBoundsSet)
 
 		FSBL.Clients.HotkeyClient.addGlobalHotkey(["ctrl", "alt", "t"], () => {


### PR DESCRIPTION
remove unused functions from toolbarStore

**Resolves issue [11653](https://chartiq.kanbanize.com/ctrl_board/18/cards/11653/details)**

**Description of change**
Adds `"canMaximize": false` to the toolbar config.

**Description of testing**
-How did you verify that your code satisfies the card's requirements?
See https://github.com/ChartIQ/finsemble/pull/1137
