### PR TITLE
12055 removed data-icon selector

### DIFF
--- a/assets/css/font-finance.css
+++ b/assets/css/font-finance.css
@@ -12,19 +12,6 @@
 
 }
 
-[data-icon]:before {
-  font-family: "font-finance" !important;
-  content: attr(data-icon);
-  font-style: normal !important;
-  font-weight: normal !important;
-  font-variant: normal !important;
-  text-transform: none !important;
-  speak: none;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-}
-
 [class^="ff-"]:before,
 [class*=" ff-"]:before {
   font-family: "font-finance" !important;


### PR DESCRIPTION
**Resolves issue [12055](https://chartiq.kanbanize.com/ctrl_board/18/cards/12055/details)**

**Description of change**
- Removed data-icon selector from font-finance

**Description of testing**
- Create an adhoc component at the URL:  https://prd-p-4pl82v44zxvm.cloud.splunk.com/en-US/app/launcher/home
- Spawn the component
- Login using Andy's credentials:
user:  andy_chartiq
pass:  Reach closely creature agree1!
- When main dashboard loads, check to make sure the items in the top navigation Toolbar read "Splunk | Messages | Settings | Activity".  (i.e., they should not appear as jumbles of Finsemble icons).


