### PR TITLE
fix: toolbar being dockable

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -488,7 +488,6 @@
 				"minHeight": 39,
 				"minWidth": 300,
 				"docked": "top",
-				"canGroup": false,
 				"options": {
 					"autoShow": false,
 					"contextMenu": false,
@@ -507,6 +506,7 @@
 				"services": {
 					"dockingService": {
 						"isArrangable": false,
+						"canGroup": false,
 						"ignoreSnappingRequests": true,
 						"ignoreTilingAndTabbingRequests": true
 					},


### PR DESCRIPTION
**Resolves issue [12105](https://chartiq.kanbanize.com/ctrl_board/18/cards/12105/details)**

# Description fo change

- Moved `canGroup` turn off in the toolbar config

# Description of testing

1. Ran Finsemble with this config change
1. Opened Welcome Component
1. Moved WC to corner of toolbar
1. [ ] **Expect** the docking icon to not appear in the toolbar
1. [ ] **Expect** resizing the window from the right side to not resize the toolbar.

# Disclosure

I have no clue why this works at all. I'm not having any modifications jump out at me in either the seed or the framework code that would make this change needed.