### PR TITLE
12053 change FDC3Server to appDirectoryEndpoint.

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -131,7 +131,6 @@
 			"MINIMUM_WIDTH": 175,
 			"defaultHeight": 39,
 			"defaultWidth": 600,
-			"enableWindowsAeroSnap": true,
 			"requireRectangularityForGroupResize": true,
 			"undockDisbandsEntireGroup": false,
 			"fillHolesOnUndock": true,

--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -219,8 +219,8 @@
 			}
 		]
 	},
-	"//appDendpoint": "If you'd like to test the server locally, point 'appDendpoint' to http://localhost:3030/v1/ and make sure to run the AppD project.",
-	"appDendpoint": "https://fpe.finsemble.com/v1/",
+	"//appDirectoryEndpoint": "If you'd like to test the server locally, point 'appDirectoryEndpoint' to http://localhost:3030/v1/ and make sure to run the AppD project.",
+	"appDirectoryEndpoint": "https://fpe.finsemble.com/v1/",
 	"globalHotkeys": {},
 	"//": "importConfig contains components that are necessary to start Finsemble. All other components are loaded dynamically. See server/auth/test.json",
 	"importConfig": [

--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -12,9 +12,6 @@
 			"IndexedDBAdapter": "$applicationRoot/adapters/indexedDBAdapter.js"
 		}
 	},
-	"FDC3Comment": "swap values for FDC3Server with LOCAL_FDC3Server after running it.",
-	"FDC3Server": "https://fpe.finsemble.com/v1/",
-	"aFDC3Server": "http://localhost:3030/v1/",
 	"servicesConfig": {
 		"distributedStore": {
 			"initialStores": [
@@ -134,6 +131,7 @@
 			"MINIMUM_WIDTH": 175,
 			"defaultHeight": 39,
 			"defaultWidth": 600,
+			"enableWindowsAeroSnap": true,
 			"requireRectangularityForGroupResize": true,
 			"undockDisbandsEntireGroup": false,
 			"fillHolesOnUndock": true,
@@ -222,6 +220,8 @@
 			}
 		]
 	},
+	"//appDendpoint": "If you'd like to test the server locally, point 'appDendpoint' to http://localhost:3030/v1/ and make sure to run the AppD project.",
+	"appDendpoint": "https://fpe.finsemble.com/v1/",
 	"globalHotkeys": {},
 	"//": "importConfig contains components that are necessary to start Finsemble. All other components are loaded dynamically. See server/auth/test.json",
 	"importConfig": [

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -31,8 +31,8 @@ let FDC3Client;
 let appd;
 
 function initialize(done = Function.prototype) {
-	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.FDC3Server" }, function (err, FDC3Server) {
-		FDC3Client = new FDC3({ url: FDC3Server });
+	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDendpoint" }, function (err, appDendpoint) {
+		FDC3Client = new FDC3({ url: appDendpoint });
 		appd = new AppDirectory(FDC3Client);
 
 

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -31,8 +31,8 @@ let FDC3Client;
 let appd;
 
 function initialize(done = Function.prototype) {
-	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDendpoint" }, function (err, appDendpoint) {
-		FDC3Client = new FDC3({ url: appDendpoint });
+	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDirectoryEndpoint" }, function (err, appDirectoryEndpoint) {
+		FDC3Client = new FDC3({ url: appDirectoryEndpoint });
 		appd = new AppDirectory(FDC3Client);
 
 

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -55,8 +55,8 @@ function getDragDisabled() {
 }
 
 function initialize(callback = Function.prototype) {
-	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDendpoint" }, function (err, appDendpoint) {
-		FDC3Client = new FDC3({ url: appDendpoint });
+	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDirectoryEndpoint" }, function (err, appDirectoryEndpoint) {
+		FDC3Client = new FDC3({ url: appDirectoryEndpoint });
 		appd = new AppDirectory(FDC3Client);
 
 		const store = getStore();

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -55,8 +55,8 @@ function getDragDisabled() {
 }
 
 function initialize(callback = Function.prototype) {
-	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.FDC3Server" }, function (err, FDC3Server) {
-		FDC3Client = new FDC3({ url: FDC3Server });
+	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.appDendpoint" }, function (err, appDendpoint) {
+		FDC3Client = new FDC3({ url: appDendpoint });
 		appd = new AppDirectory(FDC3Client);
 
 		const store = getStore();


### PR DESCRIPTION
**Resolves issue [12053](https://chartiq.kanbanize.com/ctrl_board/18/cards/12053/details)**

**Description of change**
* Change FDC3Server to appDendpoint to better reflect what the config means.
* Change code to point to new config property.

**How to test**
1. Clone this repo: https://github.com/ChartIQ/fdc-appd, npm install, and npm run start.
2. Modify the value of `appDirectoryEndpoint` in `configs/application/config.json` to point to the local server. See `//appDendpoint` in the config for instructions.
3. Modify `config.json` in `src-built-in/toolbar` and change `App Launcher` (at the bottom) to `My Apps`.
4. Modify `presentationComponents.json` so that the component named `App Catalog` is named `Not the App Catalog`.
5. Modify `presentationComponents.json` so that the component named `App Catalog2` is named `App Catalog`. Now the application will point to the new app catalog. We're actively thinking about how to upgrade this component. Bear with us for now.
6. Start the seed. Make sure the local APPD server is running.
7. Click the apps menu, then launch the app catalog.
8. Verify that there is data.