### PR TITLE
11830 - Changed data type for tabbing from text/plain to custom type

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/app.jsx
+++ b/src-built-in/components/floatingTitlebar/src/app.jsx
@@ -83,7 +83,7 @@ class FloatingTitlebar extends React.Component {
 
 	onDragStart(e) {
 		isDragging = true;
-		e.dataTransfer.setData("text/plain", JSON.stringify(storeExports.Actions.getWindowIdentifier()));
+		e.dataTransfer.setData("application/fsbl-tab-data", JSON.stringify(storeExports.Actions.getWindowIdentifier()));
 		FSBL.Clients.WindowClient.startTilingOrTabbing({
 			windowIdentifier: storeExports.Actions.getWindowIdentifier()
 		});

--- a/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
+++ b/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
@@ -102,7 +102,7 @@ export default class TabRegion extends React.Component {
         this.setState({
             iAmDragging: true
         });
-        e.dataTransfer.setData("text/plain", JSON.stringify(windowIdentifier));
+        e.dataTransfer.setData("application/fsbl-tab-data", JSON.stringify(windowIdentifier));
         FSBL.Clients.WindowClient.startTilingOrTabbing({
             windowIdentifier: windowIdentifier
         });
@@ -140,7 +140,7 @@ export default class TabRegion extends React.Component {
      */
     extractWindowIdentifier(e) {
         try {
-            let identifier = JSON.parse(e.dataTransfer.getData('text/plain'));
+            let identifier = JSON.parse(e.dataTransfer.getData('application/fsbl-tab-data'));
             //If the "identifier" is formed properly, it'll have this properly. Otherwise, it's something else (e.g., share data, image, etc).
             if (typeof identifier.windowName !== "undefined") {
                 return identifier;

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -112,7 +112,7 @@ export default class TabRegion extends React.Component {
         this.setState({
             iAmDragging: true
         });
-        e.dataTransfer.setData("text/plain", JSON.stringify(windowIdentifier));
+        e.dataTransfer.setData("application/fsbl-tab-data", JSON.stringify(windowIdentifier));
         FSBL.Clients.WindowClient.startTilingOrTabbing({
             windowIdentifier: windowIdentifier
         });
@@ -150,7 +150,7 @@ export default class TabRegion extends React.Component {
      */
     extractWindowIdentifier(e) {
         try {
-            let identifier = JSON.parse(e.dataTransfer.getData('text/plain'));
+            let identifier = JSON.parse(e.dataTransfer.getData('application/fsbl-tab-data'));
             //If the "identifier" is formed properly, it'll have this properly. Otherwise, it's something else (e.g., share data, image, etc).
             if (typeof identifier.windowName !== "undefined") {
                 return identifier;


### PR DESCRIPTION
**Resolves issue [11830](https://chartiq.kanbanize.com/ctrl_board/18/cards/11830/details)**

**Description of change**
- Changed data type for tabbing from `"text/plain"` to `"application/fsbl-tab-data"`

**Description of testing**
- Verify that windows can tab together
- Open application that accepts text drop (I used Notepad++), and drag a tab into the window. Verify that no string is dropped, and window moves to drop location
