### PR TITLE
Fixed naming and misspelling.

### DIFF
--- a/configs/application/securityPolicies.json
+++ b/configs/application/securityPolicies.json
@@ -11,8 +11,8 @@
 				"readRegistryValue": false
 			},
 			"Window": {
-				"executeJavascript": false,
-				"options": {
+				"executeJavaScript": false,
+				"webPreferences": {
 					"preload": false
 				}
 			}


### PR DESCRIPTION
**Resolves issue [12332](https://chartiq.kanbanize.com/ctrl_board/18/cards/12332/details)**

**Description of change**
Fix naming and misspelling errors in SecurityPolicy.json

**Description of testing**
-Tested in permissions branch 11995 that the correct permissions were pulled in for an untrusted policy
