### PR TITLE
12334 update to e2o 3.7.0-pre1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "license": "",
     "optionalDependencies": {
         "openfin-launcher": "^1.3.11",
-        "@chartiq/e2o": "3.7.*"
+        "@chartiq/e2o": "3.7.0-pre1.2"
     },
     "dependencies": {
         "@chartiq/finsemble": "3.7.*",


### PR DESCRIPTION
**Resolves issue [12334](https://chartiq.kanbanize.com/ctrl_board/18/cards/12334/details)**

**Description of change**
- changed e2o version to 3.7.0-pre1.2

**Description of testing**
- npm i, enabled e2o in server-environment-startup.json, finsemble works with e2o
