### PR TITLE
fix: #id 12150 removed handler that causes incorrect maximize state

### DIFF
--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -148,12 +148,6 @@ var Actions = {
 
 		FSBL.Clients.RouterClient.subscribe("Finsemble.WorkspaceService.groupUpdate", onDockingGroupUpdate);
 
-		/**
-		 * Catches a double-click on the title bar. If you don't catch this, openfin will invoke the OS-level maximize, which will put the window on top of the toolbar. `clickMaximize` will fill all of the space that finsemble allows.
-		 */
-		FSBL.Clients.WindowClient.finWindow.addEventListener("maximized", function () {
-			self.clickMaximize();
-		});
 
 		//default title.
 		windowTitleBarStore.setValue({ field: "Main.windowTitle ", value: FSBL.Clients.WindowClient.getWindowTitle() });


### PR DESCRIPTION
**Resolves issue [12150](https://chartiq.kanbanize.com/ctrl_board/18/cards/12150/details)**

**Description of change**
- Remove Handler for System Maximized event

**Description of testing**
- Double Click a windowtitlebar to maximize
- [ ] It should maximize and show the restore icon
- Double click the windowtitlebar to restore again
- [ ] The window should restore back and show the maximize icon.
