### PR TITLE
12522 isolate router service

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -216,6 +216,12 @@
 				"services": [
 					"dockingService"
 				]
+			},
+			{
+				"agentLabel": "routerService",
+				"services": [
+					"routerService"
+				]
 			}
 		]
 	},


### PR DESCRIPTION
**Resolves issue 12522 ](https://chartiq.kanbanize.com/ctrl_board/18)**

**Description of change**
-Changed config to isolate Router Service in its own splintering process 

**Description of testing**
-Brought up Finsemble and used Process Monitor to confirm Router Service was isolated. 
-Brought up large workspace with debug logging enable and confirm performance was substantially better for logging and toolbar menus (although still a little slower than desired).  
