### PR TITLE
Removed fixed height on titlebar container

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -421,7 +421,6 @@ function init () {
 	// Create the header element
 	const template = document.createElement("div");
 	const FSBLHeader = document.createElement('div')
-		  FSBLHeader.setAttribute('style', 'height: 20px')
 		  FSBLHeader.setAttribute('id', 'FSBLHeader')
 	template.appendChild(FSBLHeader)
 	document.body.insertBefore(template.firstChild, document.body.firstChild);


### PR DESCRIPTION
**Resolves issue [12656](https://chartiq.kanbanize.com/ctrl_board/18/cards/12656/details)**

**Description of change**
- Removed fixed height from title bar container

**Description of testing**
- npm run dev
- open an app
- verify that the title bar does not have an extra 20px of space under the title bar
