### PR TITLE
Remove updateURL from config as it is experimental and untested.

### DIFF
--- a/configs/other/server-environment-startup.json
+++ b/configs/other/server-environment-startup.json
@@ -10,9 +10,7 @@
         "//electronDebug": "Whether to start the finsemble-electron-adapter in debug mode. Default: true.",
         "electronDebug": true,
         "//breakpointOnStart": "Whether to pause finsemble-electron-adapter when it starts. Default: false.",
-        "breakpointOnStart": false,
-        "//updateUrl": "experimental",
-        "updateUrl": "http://localhost:3375/pkg/"
+        "breakpointOnStart": false
     },
     "production": {
         "//serverPort": "Port number for your server.",
@@ -25,8 +23,6 @@
         "//electronDebug": "Whether to start the finsemble-electron-adapter in debug mode. Default: true.",
         "electronDebug": true,
         "//breakpointOnStart": "Whether to pause finsemble-electron-adapter when it starts. Default: false.",
-        "breakpointOnStart": false,
-        "//updateUrl": "experimental",
-        "updateUrl": "http://localhost:3375/pkg/"
+        "breakpointOnStart": false
     }
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -434,7 +434,7 @@
 
 			// UpdateURL isn't required, but we let them know in case they're expecting it to work.
 			if (!updateUrl) {
-				logToTerminal(`>>>> WARNING: Installer potentially misconfigured. No property 'updateUrl' in configs/other/server-environment-startup.json under ${env.NODE_ENV}. The application will still work, but it will not update.`, "yellow");
+				logToTerminal(`[Info] Did not find 'updateUrl' in configs/other/server-environment-startup.json under ${env.NODE_ENV}. The application will still work, but it will not update itself with new versions of the finsemble-electron-adapter.`, "white");
 				updateUrl = null;
 			}
 


### PR DESCRIPTION
updating was not put through the ringer. Removes config for updates and changes the warning to info.