### PR TITLE
Fix deleting requiring two clicks when active workspace is false.

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -451,8 +451,6 @@ export default class Workspaces extends React.Component {
 
 		if (this.state.focusedWorkspace === FSBL.Clients.WorkspaceClient.activeWorkspace.name) {
 			deleteButtonClasses += " disabled-individual-workspace-action";
-			allowDelete = false;
-			deleteTooltip = "Cannot delete the active workspace";
 		}
 
 		if (this.state.focusedWorkspace === '') {


### PR DESCRIPTION
fix: #id 12618

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/12618/details)

**Description of change**
* Removed setting allowDelete false and special deleteTooltip when the active workspace is focused. There is not trashcan icon next to delete, so there is no need to check this and there were issues with this click not triggering a new focused workspace. The special tooltip would only work if it's connected to an onhover event, but is also not needed for the same reason (no trashcan icon).

**Description of testing**
1. Create two workspaces and open the preferences dialog.
1. Select the active workspace
1. [x] Can hover over workspaces trashcan and see "delete" as the tooltip.
1. [x] Clicking delete over the other workspace pops up the delete dialog after one click and has the name of the correct workspace.
1. [x] The correct workspace is deleted when yes is clicked.