### PR TITLE
Affinity default configuration

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -44,7 +44,7 @@
 		"nonConfiguredComponent": {
 			"window": {
 				"url": "$applicationRoot/components/nonConfiguredComponent/nonConfiguredComponent.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"frame": false,
 				"resizable": true,
 				"autoShow": true,

--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -4,6 +4,7 @@
 		"Welcome Component": {
 			"window": {
 				"url": "$applicationRoot/components/welcome/welcome.html",
+				"affinity": "workspaceComponents",
 				"frame": false,
 				"resizable": true,
 				"autoShow": true,
@@ -43,6 +44,7 @@
 		"nonConfiguredComponent": {
 			"window": {
 				"url": "$applicationRoot/components/nonConfiguredComponent/nonConfiguredComponent.html",
+				"affinity": "presentationComponents",
 				"frame": false,
 				"resizable": true,
 				"autoShow": true,

--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -4,6 +4,7 @@
 		"App Launcher": {
 			"window": {
 				"url": "$applicationRoot/components/appLauncher/appLauncher.html",
+				"affinity": "presentationComponents",
 				"top": 0,
 				"left": 0,
 				"width": 310,
@@ -69,6 +70,7 @@
 		"searchMenu": {
 			"window": {
 				"url": "$applicationRoot/components/searchMenu/searchMenu.html",
+				"affinity": "presentationComponents",
 				"top": 32,
 				"left": 45,
 				"width": 350,
@@ -101,6 +103,7 @@
 		"Overflow Menu": {
 			"window": {
 				"url": "$applicationRoot/components/overflowMenu/overflowMenu.html",
+				"affinity": "presentationComponents",
 				"top": 32,
 				"left": 45,
 				"width": 350,
@@ -133,6 +136,7 @@
 		"Workspace Management Menu": {
 			"window": {
 				"url": "$applicationRoot/components/workspaceManagementMenu/workspaceManagementMenu.html",
+				"affinity": "presentationComponents",
 				"top": 32,
 				"left": 45,
 				"width": 310,
@@ -167,6 +171,7 @@
 		"linkerWindow": {
 			"window": {
 				"url": "$applicationRoot/components/linker/linker.html",
+				"affinity": "presentationComponents",
 				"width": 65,
 				"height": 163,
 				"ephemeral": true,
@@ -246,6 +251,7 @@
 		"Window Context Menu": {
 			"window": {
 				"url": "$applicationRoot/components/windowContextMenu/windowContextMenu.html",
+				"affinity": "presentationComponents",
 				"top": 0,
 				"left": 100,
 				"width": 125,
@@ -280,6 +286,7 @@
 		"AdhocComponentForm": {
 			"window": {
 				"url": "$applicationRoot/components/adhocComponentForm/adhocComponentForm.html",
+				"affinity": "presentationComponents",
 				"width": 550,
 				"height": 175,
 				"position": "absolute",
@@ -313,6 +320,7 @@
 		"Docking Move Mask": {
 			"window": {
 				"url": "$applicationRoot/components/dockingGroupMask/dockingGroupMask.html",
+				"affinity": "presentationComponents",
 				"frame": false,
 				"resizable": false,
 				"showTaskbarIcon": false,
@@ -345,6 +353,7 @@
 		"yesNo": {
 			"window": {
 				"url": "$applicationRoot/components/yesNoDialog/yesNoDialog.html",
+				"affinity": "presentationComponents",
 				"width": 500,
 				"height": 223,
 				"position": "absolute",
@@ -386,6 +395,7 @@
 		"singleInput": {
 			"window": {
 				"url": "$applicationRoot/components/singleInputDialog/singleInputDialog.html",
+				"affinity": "presentationComponents",
 				"width": 480,
 				"height": 154,
 				"position": "absolute",
@@ -427,6 +437,7 @@
 		"inputAndSelection": {
 			"window": {
 				"url": "$applicationRoot/components/inputAndSelectionDialog/inputAndSelectionDialog.html",
+				"affinity": "presentationComponents",
 				"width": 587,
 				"height": 358,
 				"position": "absolute",
@@ -468,6 +479,7 @@
 		"dialogModal": {
 			"window": {
 				"url": "$applicationRoot/components/dialogModal/dialogModal.html",
+				"affinity": "presentationComponents",
 				"width": 1,
 				"height": 1,
 				"position": "absolute",
@@ -505,6 +517,7 @@
 			"window": {
 				"id": "launcher",
 				"url": "$applicationRoot/components/toolbar/toolbar.html",
+				"affinity": "presentationComponents",
 				"width": 600,
 				"height": 39,
 				"dockedHeight": 39,
@@ -560,6 +573,7 @@
 		},
 		"windowTitleBar": {
 			"window": {
+				"//": "This is never called as a component. It is compiled to js and then injected into other components",
 				"url": "$applicationRoot/components/windowTitleBar/windowTitleBar.js",
 				"top": "center",
 				"left": "center",
@@ -590,6 +604,7 @@
 		"UserPreferences": {
 			"window": {
 				"url": "$applicationRoot/components/userPreferences/userPreferences.html",
+				"affinity": "presentationComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -630,6 +645,7 @@
 		"Floating Titlebar": {
 			"window": {
 				"url": "$applicationRoot/components/floatingTitlebar/floatingTitlebar.html",
+				"affinity": "presentationComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -674,6 +690,7 @@
 		"Process Monitor": {
 			"window": {
 				"url": "$applicationRoot/components/processMonitor/processMonitor.html",
+				"affinity": "presentationComponents",
 				"width": 600,
 				"height": 700
 			},
@@ -701,6 +718,7 @@
 		"App Catalog": {
 			"window": {
 				"url": "$applicationRoot/components/appCatalog/appCatalog.html",
+				"affinity": "presentationComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -740,6 +758,7 @@
 		"App Catalog2": {
 			"window": {
 				"url": "$applicationRoot/components/appCatalog2/appCatalog.html",
+				"affinity": "presentationComponents",
 				"width": 600,
 				"height": 700,
 				"options": {

--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -4,7 +4,7 @@
 		"App Launcher": {
 			"window": {
 				"url": "$applicationRoot/components/appLauncher/appLauncher.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"top": 0,
 				"left": 0,
 				"width": 310,
@@ -70,7 +70,7 @@
 		"searchMenu": {
 			"window": {
 				"url": "$applicationRoot/components/searchMenu/searchMenu.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"top": 32,
 				"left": 45,
 				"width": 350,
@@ -103,7 +103,7 @@
 		"Overflow Menu": {
 			"window": {
 				"url": "$applicationRoot/components/overflowMenu/overflowMenu.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"top": 32,
 				"left": 45,
 				"width": 350,
@@ -136,7 +136,7 @@
 		"Workspace Management Menu": {
 			"window": {
 				"url": "$applicationRoot/components/workspaceManagementMenu/workspaceManagementMenu.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"top": 32,
 				"left": 45,
 				"width": 310,
@@ -171,7 +171,7 @@
 		"linkerWindow": {
 			"window": {
 				"url": "$applicationRoot/components/linker/linker.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 65,
 				"height": 163,
 				"ephemeral": true,
@@ -251,7 +251,7 @@
 		"Window Context Menu": {
 			"window": {
 				"url": "$applicationRoot/components/windowContextMenu/windowContextMenu.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"top": 0,
 				"left": 100,
 				"width": 125,
@@ -286,7 +286,7 @@
 		"AdhocComponentForm": {
 			"window": {
 				"url": "$applicationRoot/components/adhocComponentForm/adhocComponentForm.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 550,
 				"height": 175,
 				"position": "absolute",
@@ -320,7 +320,7 @@
 		"Docking Move Mask": {
 			"window": {
 				"url": "$applicationRoot/components/dockingGroupMask/dockingGroupMask.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"frame": false,
 				"resizable": false,
 				"showTaskbarIcon": false,
@@ -353,7 +353,7 @@
 		"yesNo": {
 			"window": {
 				"url": "$applicationRoot/components/yesNoDialog/yesNoDialog.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 500,
 				"height": 223,
 				"position": "absolute",
@@ -395,7 +395,7 @@
 		"singleInput": {
 			"window": {
 				"url": "$applicationRoot/components/singleInputDialog/singleInputDialog.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 480,
 				"height": 154,
 				"position": "absolute",
@@ -437,7 +437,7 @@
 		"inputAndSelection": {
 			"window": {
 				"url": "$applicationRoot/components/inputAndSelectionDialog/inputAndSelectionDialog.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 587,
 				"height": 358,
 				"position": "absolute",
@@ -479,7 +479,7 @@
 		"dialogModal": {
 			"window": {
 				"url": "$applicationRoot/components/dialogModal/dialogModal.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 1,
 				"height": 1,
 				"position": "absolute",
@@ -517,7 +517,7 @@
 			"window": {
 				"id": "launcher",
 				"url": "$applicationRoot/components/toolbar/toolbar.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 600,
 				"height": 39,
 				"dockedHeight": 39,
@@ -604,7 +604,7 @@
 		"UserPreferences": {
 			"window": {
 				"url": "$applicationRoot/components/userPreferences/userPreferences.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -645,7 +645,7 @@
 		"Floating Titlebar": {
 			"window": {
 				"url": "$applicationRoot/components/floatingTitlebar/floatingTitlebar.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -690,7 +690,7 @@
 		"Process Monitor": {
 			"window": {
 				"url": "$applicationRoot/components/processMonitor/processMonitor.html",
-				"affinity": "presentationComponents",
+				"affinity": "workspaceComponents",
 				"width": 600,
 				"height": 700
 			},
@@ -718,7 +718,7 @@
 		"App Catalog": {
 			"window": {
 				"url": "$applicationRoot/components/appCatalog/appCatalog.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"frame": false,
 				"top": "center",
 				"left": "center",
@@ -758,7 +758,7 @@
 		"App Catalog2": {
 			"window": {
 				"url": "$applicationRoot/components/appCatalog2/appCatalog.html",
-				"affinity": "presentationComponents",
+				"affinity": "systemComponents",
 				"width": 600,
 				"height": 700,
 				"options": {

--- a/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
+++ b/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
@@ -64,7 +64,7 @@ function prettyPrint(number, statType) {
     if (statType === "CPU") {
         //make it a percent.
         return round(number, 2) + "%";
-    } else if (statType !== "processId") {
+    } else if (statType !== "PID") {
         return bytesToSize(number);
     } else {
         return number;

--- a/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
+++ b/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
@@ -64,7 +64,7 @@ function prettyPrint(number, statType) {
     if (statType === "CPU") {
         //make it a percent.
         return round(number, 2) + "%";
-    } else if (statType !== "PID") {
+    } else if (statType !== "processId") {
         return bytesToSize(number);
     } else {
         return number;


### PR DESCRIPTION
fix: #id [13055]

Requires fea pr: https://github.com/ChartIQ/finsemble-electron-adapter/pull/84

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13055/details)

**Description of change**
* Adds default configuration that enables affinity. Based on this branch: https://github.com/ChartIQ/finsemble-seed/compare/develop...services_as_scripts taking only the affinity-related config changes and making a few naming changes:
- presentationComponents are renamed to systemComponents so they won't show in simple mode of process monitor
- Process monitor is moved from systemComponents to workspaceComponents. Because of a memory leak bug all apps reloaded by a workspace need to be in the same affinity.

**Description of testing**
See https://github.com/ChartIQ/finsemble-electron-adapter/pull/84 for testing.