### PR TITLE
fix: #id 12383 Fix pid label for process monitor fix

### DIFF
--- a/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
+++ b/src-built-in/components/processMonitor/src/components/ProcessStatistics.jsx
@@ -64,7 +64,7 @@ function prettyPrint(number, statType) {
     if (statType === "CPU") {
         //make it a percent.
         return round(number, 2) + "%";
-    } else if (statType !== "processId") {
+    } else if (statType !== "PID") {
         return bytesToSize(number);
     } else {
         return number;


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/12383/details)

Requires: https://github.com/ChartIQ/finsemble-electron-adapter/pull/86

**Description of change**
* Fixes pid label for process monitor

**Description of testing**
See fea pr above.