### PR TITLE
fix: 13333 accountList window is not showing any content

### DIFF
--- a/tutorials/accountDetail/accountDetail.js
+++ b/tutorials/accountDetail/accountDetail.js
@@ -62,7 +62,7 @@ function communicateBetweenComponents() {
 /**
  * Everything needs to happen after Finsemble is ready
  */
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	getInitialCustomer();
 	getState();

--- a/tutorials/accountList/accountList.js
+++ b/tutorials/accountList/accountList.js
@@ -136,7 +136,7 @@ function communicateBetweenComponents() {
 	// });
 }
 
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	//alert(FSBL.Clients.WindowClient.options.customData.component["account-type"]); // --> Step 1.4
 

--- a/tutorials/accountStatement/accountStatement.js
+++ b/tutorials/accountStatement/accountStatement.js
@@ -34,7 +34,7 @@ function createLinkage() {
 	});
 }
 
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	createLinkage();
 	getState();


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id 13333

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13333/details/)

**Description of change**
* Changes

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Step 1. Clone seed project
1. Step 2. Create components accountList and accountDetail from the finsemble cli and add files accountList and accountDetail from the tutorial folder to the component folder
1. Step 3. Run the app, and the account list window should show a list of the preset accounts