### PR TITLE
fix: #id 12742 Fix Toolbar Maximizing at top of monitor.

### DIFF
--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -539,7 +539,8 @@
 					"autoShow": false,
 					"contextMenu": false,
 					"showTaskbarIcon": false,
-					"smallWindow": true
+					"smallWindow": true,
+					"maximizable": false
 				}
 			},
 			"component": {


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/12742/details)

**Description of change**
* Add 'maximizable' property to window options for toolbar. This is passed down to the container and prevents the toolbar from maximizing.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Start up in openfin. 
1. Double-click the toolbar -- no maximize.
1. Try to maximize the toolbar by dragging above the monitor -- no maximize.

Do the same in electron. The behavior reported in the card no longer happens.