### PR TITLE
Moved Electron existence check to launchElectron

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -289,12 +289,6 @@
 			const CONTROLS_PATH = path.join(__dirname, "node_modules", "@chartiq", "finsemble-react-controls");
 			const CONTROLS_VERSION = require(path.join(CONTROLS_PATH, "package.json")).version;
 
-			// Check electron adapter version
-			const USING_ELECTRON = container === "electron";
-			if (USING_ELECTRON && !FEA_PATH_EXISTS) {
-				throw "Cannot use electron container unless finsemble-electron-adapter optional dependency is installed. Please run npm i @chartiq/finsemble-electron-adapter";
-			}
-
 			// Check version before require so optionalDependency can stay optional
 			const FEA_VERSION = FEA_PATH_EXISTS ? require(path.join(FEA_PATH, "package.json")).version : undefined;
 
@@ -400,6 +394,11 @@
 			if (done) done();
 		},
 		launchElectron: done => {
+			const USING_ELECTRON = container === "electron";
+			if (USING_ELECTRON && !FEA_PATH_EXISTS) {
+				throw "Cannot use electron container unless finsemble-electron-adapter optional dependency is installed. Please run npm i @chartiq/finsemble-electron-adapter";
+			}
+
 			let config = {
 				manifest: taskMethods.startupConfig[env.NODE_ENV].serverConfig
 			}


### PR DESCRIPTION
Same as https://github.com/ChartIQ/finsemble-seed/pull/361 for 3.9

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13097/details)

**Description of change**
* Moved Electron existence check to launchElectron 

**Description of testing**
1. Run `git clean -xfd` and make sure _node_modules_ is deleted
1. Remove `"@chartiq/finsemble-electron-adapter"` entry from `optionalDependencies` in _package.json_
1. Run `npm i`
1. Run `npm run build`
1. [x] Finsemble builds without error
1. Run `npm run dev`
1. [x] Finsemble fails to run with the following error:
    `Cannot use electron container unless finsemble-electron-adapter optional dependency is installed. Please run npm i @chartiq/finsemble-electron-adapter`
1. Revert change to _package.json_
1. Run `git clean -xfd`
1. Run `npm i`
1. Run `npm run build`
1. [x] Finsemble builds without errors
1. Run `npm run dev`
1. [x] Finsemble runs without errors