### PR TITLE
13492 seed fsbl eventname

### DIFF
--- a/tutorials/accountDetail/accountDetail.js
+++ b/tutorials/accountDetail/accountDetail.js
@@ -62,7 +62,7 @@ function communicateBetweenComponents() {
 /**
  * Everything needs to happen after Finsemble is ready
  */
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	getInitialCustomer();
 	getState();

--- a/tutorials/accountList/accountList.js
+++ b/tutorials/accountList/accountList.js
@@ -136,7 +136,7 @@ function communicateBetweenComponents() {
 	// });
 }
 
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	//alert(FSBL.Clients.WindowClient.options.customData.component["account-type"]); // --> Step 1.4
 

--- a/tutorials/accountStatement/accountStatement.js
+++ b/tutorials/accountStatement/accountStatement.js
@@ -34,7 +34,7 @@ function createLinkage() {
 	});
 }
 
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLready", FSBLReady) }
+if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {
 	createLinkage();
 	getState();


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id 13492 

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13492/details/)

**Description of change** Event name needs to be updated in the tutorial components for when FSBL onReady function handler is triggered.
* Changes event name changed from FSBLready to FSBLReady

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Step 1. Add the accountStatement, accountDetails, and accountList components to the seed project.
1. Step 2. Verify you can open accountStatement, accountDetails, and accountList components and that the FSBLReady function is called correctly for each.