### PR TITLE
fix: #id 13539 dont show services, hide windows if they were hidden

### DIFF
--- a/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
+++ b/src-built-in/components/processMonitor/src/stores/ProcessMonitorStore.js
@@ -189,25 +189,40 @@ var Actions = {
 	 * Make the window flash a couple of times so that the user can identify it.
 	 */
 	identifyWindow: function (winID) {
+		if (winID.name.includes("Service")) return;
+
 		const OPACITY_ANIMATION_DURATION = 200;
 		let win = fin.desktop.Window.wrap(winID.uuid, winID.name);
 		let windowState = "hidden";
+
 		function flash(n, done) {
-			win.animate({
-				opacity: {
-					opacity: 0.5,
-					duration: OPACITY_ANIMATION_DURATION
-				}
-			}, {}, () => {
+			if (fin.container !== "Electron") { // Animate doesn't work in electron yet.
 				win.animate({
 					opacity: {
-						opacity: 1,
+						opacity: 0.5,
 						duration: OPACITY_ANIMATION_DURATION
 					}
 				}, {}, () => {
-					done(null);
-				});
-			})
+					win.animate({
+						opacity: {
+							opacity: 1,
+							duration: OPACITY_ANIMATION_DURATION
+						}
+					}, {}, () => {
+						done(null);
+					});
+				})
+			} else {
+				setTimeout(() => {
+					win.hide(() => {
+						setTimeout(() => {
+							win.show(() => {
+								done(null);
+							});
+						}, OPACITY_ANIMATION_DURATION / 1.5);
+					});
+				}, OPACITY_ANIMATION_DURATION / 1.5);
+			}
 		}
 		win.isShowing(isVisible => {
 			//cache the visible state of the window prior to making it flash. If it was hidden before, hide it when the flashing is done.


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13539/details)

**Description of change**
* Do not show windows for Services when they are clicked on in Process Monitor advanced mode
* Animate does not work in electron, so use show and hide instead.

**Description of testing**
1. start process monitor. 
1. switch to advanced mode. 
1. Click on a bunch of items in the list
1. [ ] Service windows don't show up. 
1. [ ] Other windows should flash
1. Test in both electron and openfin