### PR TITLE
Fix #13686 FSBLReady event listened for to bootstrap components.

### DIFF
--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -295,7 +295,13 @@ export default class AppMarket extends React.Component {
 	}
 }
 
-FSBL.addEventListener("onReady", function () {
+if (window.FSBL && FSBL.addEventListener) { 
+	FSBL.addEventListener("onReady", FSBLReady); 
+} else { 
+	window.addEventListener("FSBLReady", FSBLReady);
+}
+
+function FSBLReady() {
 	createStore((store) => {
 		storeActions.initialize(() => {
 			ReactDOM.render(
@@ -303,4 +309,4 @@ FSBL.addEventListener("onReady", function () {
 				document.getElementById("bodyHere"));
 		});
 	});
-});
+}

--- a/src-built-in/components/myApps/src/index.jsx
+++ b/src-built-in/components/myApps/src/index.jsx
@@ -93,12 +93,18 @@ class AppLauncher extends React.Component {
 }
 
 fin.desktop.main(function () {
-	FSBL.addEventListener("onReady", function () {
+	if (window.FSBL && FSBL.addEventListener) { 
+		FSBL.addEventListener("onReady", FSBLReady); 
+	} else {
+		window.addEventListener("FSBLReady", FSBLReady);
+	} 
+
+	function FSBLReady(){
 		createStore((store) => {
 			storeActions.initialize(() => {
 				ReactDOM.render(<AppLauncher />,
-					document.getElementById("wrapper"));
+				document.getElementById("wrapper"));
 			});
 		});
-	});
+	}
 });


### PR DESCRIPTION
fix: #13686 [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13686/details/)

**Description of change** event handler added to appCatalog2 to check when finsemble was fully loaded. MyApps event handlers for ready function formatting cleaned up.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Step 1. Change the following from "App Catalog" to "App Catalog old" https://github.com/ChartIQ/finsemble-seed/blob/13686-initialise-on-fsbl-ready/configs/application/presentationComponents.json#L718
1. Step 2. Change the following from "App Catalog 2" to "App Catalog" https://github.com/ChartIQ/finsemble-seed/blob/13686-initialise-on-fsbl-ready/configs/application/presentationComponents.json#L758
1. Step 3. Run the app and click on "Apps --> App Catalog" 
1. [ ] You should see the App Catalog component displayed.