### PR TITLE
fix: #id 13489 revert change to workspace format

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/stores/tabbingStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/tabbingStore.js
@@ -176,12 +176,12 @@ var Actions = {
 		if (Actions.parentWrapper) {
 			cb();
 		} else {
-			FSBL.Clients.WindowClient.getStackedWindow(params, (err, response) => {
+			FSBL.Clients.WindowClient.getStackedWindow(params, (err, wrap) => {
 				if (err) {
 					Actions.parentWrapper = null;
 					Actions._setTabs(null)
 				} else {
-					Actions.parentWrapper = attachedWindow.getParent();
+					Actions.parentWrapper = wrap;
 					Actions.setupStore(cb);
 				}
 			})

--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -148,7 +148,7 @@ export default class Workspaces extends React.Component {
 		var componentMap = {};
 		var annotatedComponentList = [];
 		for (let i = 0; i < templateObject.windows.length; i++) {
-			let windowData = templateObject.windows[i];
+			let windowData = templateObject.windowData[i];
 			FSBL.Clients.Logger.system.debug("getComponentTypes loop", windowData);
 			componentType = "Unknown Component";
 			if (windowData) { // current assimilation doesn't fill in windowData, so in this case use "Unknown Component" for component type

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -564,12 +564,12 @@ var Actions = {
 		if (Actions.parentWrapper) {
 			cb();
 		} else {
-			FSBL.Clients.WindowClient.getStackedWindow(params, (err, response) => {
+			FSBL.Clients.WindowClient.getStackedWindow(params, (err, wrap) => {
 				if (err) {
 					Actions.parentWrapper = null;
 					Actions._setTabs(null)
 				} else {
-					Actions.parentWrapper = FSBL.Clients.WindowClient.finsembleWindow.getParent();
+					Actions.parentWrapper = wrap;
 					Actions.setupStore(cb);
 				}
 			})


### PR DESCRIPTION
fix: #id 13489

**Description of change**
* This fix preserves backward compatibility with 3.8.x for workspace format. Related to https://github.com/ChartIQ/finsemble/pull/1288

**Description of testing**
* See https://github.com/ChartIQ/finsemble/pull/1288