### PR TITLE
id: #13493 fix search bar highlighting text on selection

### DIFF
--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -11,7 +11,7 @@ export default class Search extends React.Component {
 		this.state = {
 			ready: false,
 			focus: false,
-			saveText: null,
+			saveText: '',
 			active: false
 		};
 		this.bindCorrectContext();
@@ -161,7 +161,7 @@ export default class Search extends React.Component {
 		}, 100);
 	}
 	blurred() {
-		storeExports.Actions.setFocus(false)
+		storeExports.Actions.setFocus(false);
 	}
 	keyPress(event) {
 		var events = ["ArrowUp", "ArrowDown", "Enter"]

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -50,7 +50,7 @@ var Actions = {
 	},
 	setFocus(bool, target) {
 		focus = bool;
-		if (!menuWindow) return;
+		if (!menuWindow) return Actions.handleClose();
 		if (bool) {
 			if (window.outerWidth < 400) {
 				finsembleWindow.getBounds((err, bounds) => {
@@ -76,11 +76,11 @@ var Actions = {
 				Actions.positionSearchResults();
 			});
 
+		} else {
+			var sel = window.getSelection();
+			sel.removeAllRanges();
 		}
 		activeSearchBar = false;
-		if (!menuWindow) {
-			return Actions.handleClose();
-		}
 		menuWindow.isShowing(function (err, showing) {
 			if (err) { FSBL.Clients.Logger.error(`menuWindow.isShowing failed, error:`, err); }
 			//if (!showing) return//console.log("not showing")

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -77,7 +77,7 @@ var Actions = {
 			});
 
 		} else {
-			var sel = window.getSelection();
+		const sel = window.getSelection();
 			sel.removeAllRanges();
 		}
 		activeSearchBar = false;

--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -233,13 +233,6 @@ var Actions = {
 		}
 	},
 
-	setBlurSearchInputHandler(blurHandler) {
-		if (typeof blurHandler !== 'function') {
-			FSBL.Clients.Logger.error("Parameter blurHandler must be a function.");
-		} else {
-			blurSearchInputHandler = blurHandler;
-		}
-	},
 
 	/**
 	 * Perform the search action

--- a/src-built-in/components/toolbar/toolbar.css
+++ b/src-built-in/components/toolbar/toolbar.css
@@ -74,7 +74,7 @@ body, html {
 .searchInput.compact {
     content: "";
     padding-left: 9px;
-    width: 23px;
+    width: 30px;
     cursor: pointer;
     color: transparent; /* hide the text when in compact mode */
   /*transition: width .5s,background-color 0s .5s;*/;
@@ -125,7 +125,7 @@ img {
 .searchInput::after {
     position: absolute;
     font-family: font-finance;
-    right: 10px;
+    right: 24px;
     content: "\2c";
     color: var(--toolbar-font-color); /* make sure magnifying glass is white */
 }


### PR DESCRIPTION
fix: #id [13493]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13493/details/)

**Description of change**
* Remove the range (highlight) of the search text when user click away
* Remove duplicated code

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Run Finsemble seed
1. Type something in the search bar in the tool bar
1. Select a search result
1. Click into the search bar again and select the search result
1. [x] We can no longer see the highlighted search text