### PR TITLE
fix: #id 13955 toolbar registered hotkeys not working

### DIFF
--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -138,6 +138,7 @@ export default class Search extends React.Component {
 	}
 	hotKeyActive() {
 		this.setState({ active: true, hotkeySet: true })
+		this.searchInput.current.focus();
 	}
 	focused(e) {
 		function selectElementContents(el) {

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -267,11 +267,11 @@ class _ToolbarStore {
 				if (err) { FSBL.Clients.Logger.error(`HotkeyClient.addGlobalHotkey failed, error:`, err); }
 				FSBL.Clients.LauncherClient.bringWindowsToFront()
 			});
-			FSBL.Clients.HotkeyClient.addGlobalHotkey([keys.ctrl, keys.alt, keys.down], () => {
+			FSBL.Clients.HotkeyClient.addGlobalHotkey([keys.ctrl, keys.alt, keys.down], (err) => {
 				if (err) { FSBL.Clients.Logger.error(`HotkeyClient.addGlobalHotkey failed, error:`, err); }
 				FSBL.Clients.WorkspaceClient.minimizeAll()
 			});
-			FSBL.Clients.HotkeyClient.addGlobalHotkey([keys.ctrl, keys.alt, keys.f], () => {
+			FSBL.Clients.HotkeyClient.addGlobalHotkey([keys.ctrl, keys.alt, keys.f], (err) => {
 				if (err) { FSBL.Clients.Logger.error(`HotkeyClient.addGlobalHotkey failed, error:`, err); }
 				self.Store.setValue({ field: "searchActive", value: true });
 			});


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13955/details)
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13956/details)

**Description of change**
* Added err to callback so that check for if(err) doesn't fail.

**Description of testing**
1. Test that pinned items hotkeys (Ctrl + Alt + 1, 2 etc. work)
1. That that Ctrl + Alt + Down Arrow minimizes all (Ctrl + Alt + Up restores all)