### PR TITLE
fix: #id 13967 Fix search menu hide behavior on enter

### DIFF
--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -101,7 +101,14 @@ export default class Search extends React.Component {
 	}
 
 	textChangeDebounced(event) {
-		storeExports.Actions.search(event.target.textContent);
+		// The event.nativeEvent is of type 'InputEvent'. nativeEvent.data gives us new keys that were added
+		// If the user presses enter, this event will still trigger, but there's no data.
+		// If the user is using hotkeys to scroll through search results and they hit enter, we don't want to search,
+		// as that will position the search results.
+		// So if the data is null, we skip the search.
+		if (event.nativeEvent.data) {
+			storeExports.Actions.search(event.target.textContent);
+		}
 	}
 	componentDidUpdate() {
 		if (this.state.hotkeySet) {


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13967/details)


* Previously, if one typed in a search, pressed the down arrow, and
pressed enter, the search menu would reappear after launching the component.

This is fixed.

**Description of change**
* Changes

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Type into the seach box 'we'.
1. Press the down arrow.
1. Hit enter.

Observe that the search menu hides and does not reopen.