### PR TITLE
fix: #13977 Edit workspaces name in preferences

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -104,7 +104,6 @@ export default class Workspaces extends React.Component {
 		this.setState({
 			workspaceList: data.value
 		});
-		this.cancelEdit();
 	}
 
 	addListeners() {


### PR DESCRIPTION
fix: #id13977

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13977/details)

**Description of change**
* Removed unnecessary `this.cancelEdit()` from `setWorkspaceList()`

**Description of testing**

- Checkout this branch 
- Launch finsemble `npm run dev`
- Open user preferences > workspaces

- [ ] You can rename workspaces by clicking on the pen icon
