### PR TITLE
fix: #13995 Prevent app catalog from sitting on top of new app form

### DIFF
--- a/src-built-in/components/adhocComponentForm/app.jsx
+++ b/src-built-in/components/adhocComponentForm/app.jsx
@@ -38,6 +38,7 @@ class AdHocComponentForm extends React.Component {
 		};
 
 		document.body.addEventListener("keydown", onkeydown);
+		FSBL.Clients.WindowClient.setAlwaysOnTop(true);
 	}
 	/**
 	 * Hides the window when the save button is clicked.


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13995/details)

**Description of change**
* Call alwaysOnTop on componentDidMount so that the new app menu sits on top of everything else.


**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Click 'my apps'. Open app catalog.
1. Click 'my apps'. Click 'new app'.
1. Observe that the new app form is on top of the app catalog.