### PR TITLE
Add removeFromWorkspace true to closeTab

### DIFF
--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -483,7 +483,7 @@ var Actions = {
 	closeTab: function (windowIdentifier) {
 		//return Actions.parentWrapper.deleteWindow({ windowIdentifier }) // this will cause the window to be closed but keep the stack intact
 		FSBL.FinsembleWindow.getInstance(windowIdentifier, (err, wrap) => {
-			wrap.close();
+			wrap.close({ removeFromWorkspace: true });
 		});
 	},
 	reorderTab: function (tab, newIndex) {


### PR DESCRIPTION
fix: #id [14145]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14145/details)

**Description of change**
* Added `removeFromWorkspace: true` to the close of `closeTab` in the UI.

**Description of testing**
1. Tab a notepad onto a welcome component.
1. Activate the welcome component tab.
1. Close the notepad tab.
1. Reload the workspace.
1. [x] The workspace reloads succesfully
