### PR TITLE
Floating titlebar fix

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/stores/tabbingStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/tabbingStore.js
@@ -104,7 +104,10 @@ var Actions = {
 		return Actions.parentWrapper.removeWindow({ windowIdentifier: wi, position: i });
 	},
 	closeTab: function (wi) {
-		return Actions.parentWrapper.deleteWindow({ windowIdentifier: wi })
+		return FSBL.FinsembleWindow.getInstance(wi, (err, wrap) => {
+			FSBL.Clients.Logger.system.debug("floating titlebar closeTab", wi);
+			wrap.close({ removeFromWorkspace: true });
+		});
 	},
 	reorderTab: function (tab, newIndex) {
 


### PR DESCRIPTION
fix: #14222

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14222/details)

**Description of change**
When the floating title bar (i.e companion window) closeTab is invoked, then close the window with the parameter set to remove it from the workspace.  This closeTab function is invoked when a notepad window's tab is closed within a stacked window.   

**Description of testing**
1. change the seed config to run on OpenFin
1. create a stacked window of five notepads.
1. close each of the tabs, one by one (in different orders, alternating active and inactive tab).
1. Then reload the workspace

Do the same test above three times until 1) no windows are left, 2) one window is left (without a stacked window), 3) and two windows are left (i.e. the stacked window with two tabs).  Each time the workspace should reload with no problems.

_NOTE: Doing the tests above will cause a variety of logging errors, some from the floating title bar window.  These logging errors are independent of the fix (and should be fixed in another ticket)._
