### PR TITLE
fix: search store for toolbar not closing the results window

### DIFF
--- a/src-built-in/components/toolbar/stores/searchStore.js
+++ b/src-built-in/components/toolbar/stores/searchStore.js
@@ -189,6 +189,8 @@ var Actions = {
 						cachedBounds = null;
 					});
 				}
+				window.getSelection().removeAllRanges();
+				menuWindow.hide();
 			}
 			//These lines handle closing the searchInput box. As showing is only true when the search results
 			//menu opens, they need to be outside so the search inputbox will still close when there is no text string.


### PR DESCRIPTION
This applies back the emptying of the list and hiding of the search
results window when a user is done searching.

The removal was introduced in a bad merge of 3.10.0 into the original PR
branch.

fix: [14494](https://chartiq.kanbanize.com/ctrl_board/18/cards/14494/details/)

**Description of testing**

1. Run Finsemble
1. Open the search box in the toolbar
1. Search for something like "We"
1. Click out onto the desktop to remove focus from the search input
1. [x] EXPECT the search results window to close
1. Open the search box again
1. Focus the search input for typing and see the results window
1. Press `esc`
1. [x] EXPECT the search results window to close with the input
1. Open the search box again
1. Select the Welcome Component entry
1. [x] EXPECT the search results window to close with the input and a welcome component open
1. Open the central logger
1. Filter for errors only
1. [x] EXPECT no errors to be present from calling "isShowing" when it doesn't exist from the toolbar.
