### PR TITLE
visual code settings added to debug electron and server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,8 @@
 .project
 node_modules
 dist/
-.vscode
+.vscode/tasks.json
+.vscode/settings.json
 .idea
 .DS_Store
 apps

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Node Server",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/server/server.js"
+        },
+        {
+            "name": "Electron Main",
+            "type": "node",
+            "request": "launch",
+            "program": "${workspaceFolder}/node_modules/@chartiq/finsemble-electron-adapter/startup/devIndex.js",
+            "stopOnEntry": false,
+            "args": ["ELECTRON_DEV=true"],
+            "cwd": "${workspaceRoot}/node_modules/@chartiq/finsemble-electron-adapter",
+            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "runtimeArgs": [
+                "--remote-debugging-port=9090 --inspect=5858",
+                "--manifest http://localhost:3375/configs/openfin/manifest-local.json"
+            ],
+            "env": {}
+        },
+    ],
+    "compounds": [
+        {
+            "name": "Node Server + Electron Main",
+            "configurations": ["Node Server", "Electron Main"]
+        }
+    ]
+}


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #13843 [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13843/details/)

**Description of change**
* Changes
Settings added to visual code to debug the electron main process.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Step 1. Make sure you don't have any dangling electron processes by running 'taskkill /F /IM electron.* /T'
1. Step 2. Open visual code set a breakpoint in \node_modules\@chartiq\finsemble-electron-adapter\startup\devIndex.js on the app.on('ready', () => { ... } function.
1. Step 3. Click on the debugger button in visual code and launch 'Node Server + Electron Main'
1. Step 4. The debugger should stop on the breakpoint you set and you should be able to step through the electron main process js code.