### PR TITLE
fix: #id [14047] tab changing issues in sales demo

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -284,14 +284,14 @@ class WindowTitleBar extends React.Component {
 		let { tabs } = this.state;
 		let myIdentifier = FSBL.Clients.WindowClient.getWindowIdentifier();
 		
-		tabs = tabs.map((el, i) => {
+		tabs = tabs.map((el) => {
 			if (!el.windowName && el.name) el.windowName = el.name;
 			if (!el.name && el.windowName) el.name = el.windowName;
 			return el;
 		});
 
-		let myIndex = tabs.findIndex(el => el.name === myIdentifier.windowName);
-		if(myIndex === -1) return;
+		const myIndex = tabs.findIndex(el => el.name === myIdentifier.windowName);
+		if (myIndex === -1) return;
 
 		let myTab = tabs[myIndex] || {};
 		myTab.title = response.value;

--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -283,18 +283,17 @@ class WindowTitleBar extends React.Component {
 	onTitleChange(err, response) {
 		let { tabs } = this.state;
 		let myIdentifier = FSBL.Clients.WindowClient.getWindowIdentifier();
-		let myIndex = -1;
-		tabs = tabs.filter((el, i) => {
+		
+		tabs = tabs.map((el, i) => {
 			if (!el.windowName && el.name) el.windowName = el.name;
 			if (!el.name && el.windowName) el.name = el.windowName;
-
-			if (el.name === myIdentifier.windowName) {
-				myIndex = i;
-				return true;
-			}
-			return false;
+			return el;
 		});
-		let myTab = tabs[0] || {};
+
+		let myIndex = tabs.findIndex(el => el.name === myIdentifier.windowName);
+		if(myIndex === -1) return;
+
+		let myTab = tabs[myIndex] || {};
 		myTab.title = response.value;
 		tabs.splice(myIndex, 1, myTab);
 


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14047/details)

**Description of change**
* Fixes onTitleChanged function which is supposed to update the title in array of tabs, but was instead removing other tabs from the array.

**Description of testing**

To test in regular finsemble:
1. Start finsemble and stack two process monitor components
1. With the left tab focused, open the devtools for that tab and run 'FSBL.Clients.WindowClient.setWindowTitle('fake')'
1. [x] Click on the non-focused tab, it should switch tabs as expected

To test in Sales-Demo (where the reported bug actually happens):
This very hard, we want to find a better way, but currently there is a bug in seed affecting the build of sales demo so this is the only way right now.
Setup:
1. Pull down the develop branch of Sales-demo and make sure it is linked to 3.11 for finsemble and fea
2. Build finsemble and fea as usual
3. Run npm install in the sales demo directory
4. Next run npm run build:dev, quit out if the command is listening after the build
7. You'll need to paste the updated function into the webpack version of the windowTitlebar code. This is in dist/components/windowTitleBar/windowTitleBar.js. Search for onTitleChange and copy the entire function to replace the existing version.
8. To be safe clear your cache folder
8. Run npm run nobuild:dev so that webpack file is not overwritten.

Test:
1. You can do the same test as before with two process monitors
2. To test the workspace load failure case: Stack two simple charts. Make sure the focused tab is the one on the left, then save the workspace.
3. Reload the workspace and try to change tabs, it should change properly.