### PR TITLE
13862 - Added manual focus to linker window on show

### DIFF
--- a/src-built-in/components/linker/src/linker.jsx
+++ b/src-built-in/components/linker/src/linker.jsx
@@ -111,6 +111,18 @@ fin.desktop.main(function () {
 	if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 	function FSBLReady() {
 		LinkerStore.initialize();
+		finsembleWindow.addEventListener("shown", () => {
+			/** DH 6/19/2019
+			 * Because Finsemble uses a combination of
+			 * native OS and synthetic window events,
+			 * it's possible for the Linker Window to
+			 * have OS level focus but Finsemble not
+			 * be aware of it. Therefore, we must trigger
+			 * focus manually until we can figure out a
+			 * better way of synchronizing these states.
+			*/
+			finsembleWindow.focus();
+		});
 		ReactDOM.render(<Linker />, document.getElementById("main"));
 	}
 });


### PR DESCRIPTION
fix: #id [13862]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/13862/details)

**Description of change**
Because the OS and container maintain separate records of which window has focus, they were getting out of sync in the case of WPF windows and the Linker Window, causing the Linker to stick around after the WPF window regained focus (according to Windows). To fix this, we added the notion of a "remote focus" event, whereby assimilation and WPF can signal to Finsemble via listen/transmit that a window outside of Finsemble's knowledge has received focus. When this happens, Finsemble blurs whichever window last had focus (we rely on the existing mechanisms to focus the correct window).

- Added new "focused" state to OpenFinWindow class that toggles as the window is focused and blurred.
- Added a new handler for "remoteFocus" that blurs the previously focused window.
- In Finsemble-DLL, added a new click handler that transmits a remote focus on every click.

**Description of testing**
This testing requires the following PRs in finsemble and in finsemble-dll:
https://github.com/ChartIQ/finsemble-dll/pull/26
https://github.com/ChartIQ/finsemble/pull/1360

Config for testing WPF Demo (You will need to change the path after building)
```
		"WPFDemo": {
			"window": {
				"id": "WPFDemo",
				"windowType": "native",
				"path": "C:\\Users\\Sidd\\Documents\\GitHub\\finsemble-dotnet-internal\\WPFExample\\bin\\Release\\WPFExample.exe",
				"url": "",
				"defaultHeight": 600,
				"autoShow": true,
				"alwaysOnTop": false,
				"resizable": true,
				"showTaskbarIcon": false,
				"contextMenu": true,
				"addToWorkspace": true
			},
			"foreign": {
				"services": {
					"workspaceService": {
						"isArrangable": true
					}
				},
				"components": {
					"App Launcher": {
						"launchableByUser": true
					},
					"Window Manager": {
						"persistWindowState": false,
						"FSBLHeader": true
					},
					"Toolbar": {
						"iconURL": "$applicationRoot/assets/img/notepad.png"
					}
				}
			}
		},
```


These tests needs to be run in both OF and Electron
1. Launch WPFExample
1. Open the Linker Window
1. Move the WPFExample window
1. [ ] Linker Window closes immediately.
1. This is a non-trivial change to how focus works. Test to make sure all Finsemble menu's still behave appropriately. If you can think of more formal test cases for this PR, please let us know.