### PR TITLE
fix: 14653 fix recrusive find

### DIFF
--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -4,7 +4,7 @@ const glob_entries = require('webpack-glob-entries');
 const webpack = require("webpack");
 const fs = require("fs");
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const __homename = path.join(__dirname, "../../");
+const __homename = path.resolve(__dirname, "..", "..");
 
 // The standard webpack files that we always look in
 // webpack.finsemble-built-in.entries.json - src-built-in components
@@ -50,7 +50,7 @@ listOfWebpackEntryFiles.push(...recursiveFind(srcPath, "finsemble.webpack.json")
 // Compile all of those files into a single webpack entries object "componentsToBuild"
 // If a file doesn't exist, then no big deal ": {}"
 let componentsToBuild = {};
-listOfWebpackEntryFiles.forEach(function (filename) {
+listOfWebpackEntryFiles.forEach((filename) => {
 	let entries = fs.existsSync(filename) ? require(filename) : {};
 	let componentDirectory = path.dirname(filename);
 	let subDirectory = componentDirectory.replace(/^.*[\\\/]/, '');
@@ -58,11 +58,13 @@ listOfWebpackEntryFiles.forEach(function (filename) {
 	let additionalComponents = {};
 	if (Array.isArray(entries)) {
 		// Process arrays (finsemble.webpack.json files) by automatically building the output & entry fields that webpack needs
-		entries.forEach(function (assetName) {
-			let assetNoSuffix = assetName.replace(/\.[^/.]+$/, ""); // Remove the .js or .jsx extension
+		entries.forEach((assetName) => {
+			const outputPath = path.relative(srcPath, path.dirname(filename));
+			const assetNoSuffix = assetName.replace(/\.[^/.]+$/, ""); // Remove the .js or .jsx extension
+			const entryPath = path.relative(__homename, path.dirname(filename))
 			additionalComponents[assetNoSuffix] = {
-				output: "/" + subDirectory + "/" + assetNoSuffix,
-				entry: "./src/" + subDirectory + "/" + assetName
+				output: path.join(outputPath, assetNoSuffix),
+				entry: path.join(entryPath, assetName)
 			};		
 		});		
 	} else {

--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -52,8 +52,6 @@ listOfWebpackEntryFiles.push(...recursiveFind(srcPath, "finsemble.webpack.json")
 let componentsToBuild = {};
 listOfWebpackEntryFiles.forEach((filename) => {
 	let entries = fs.existsSync(filename) ? require(filename) : {};
-	let componentDirectory = path.dirname(filename);
-	let subDirectory = componentDirectory.replace(/^.*[\\\/]/, '');
 
 	let additionalComponents = {};
 	if (Array.isArray(entries)) {
@@ -64,7 +62,7 @@ listOfWebpackEntryFiles.forEach((filename) => {
 			const entryPath = path.relative(__homename, path.dirname(filename))
 			additionalComponents[assetNoSuffix] = {
 				output: path.join(outputPath, assetNoSuffix),
-				entry: path.join(entryPath, assetName)
+				entry: `.${path.sep}${path.join(entryPath, assetName)}`
 			};		
 		});		
 	} else {

--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -18,10 +18,11 @@ var listOfWebpackEntryFiles = [
 const srcPath = path.join(__homename, "src");
 
 /**
+ * Recursively searches a path for files of a specific name.
  * 
  * @param {string} base The base path 
  * @param {string} searchFilename the name of the file to search for
- * @param {string[]} 
+ * @param {string[]} array of file/folder names to search in base path
  * @param {string[]} result array of files found 
  */
 const recursiveFind = (base, searchFilename, files, result) => {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "optionalDependencies": {
         "openfin-launcher": "1.3.12",
         "@chartiq/finsemble-cli": "3.3.1",
-        "@chartiq/finsemble-electron-adapter": "3.9.0"
+        "@chartiq/finsemble-electron-adapter": "https://assets.finsemble.com/dev/chartiq-finsemble-electron-adapter-3.10.0.tgz"
     },
     "dependencies": {
-        "@chartiq/finsemble": "3.9.0",
+        "@chartiq/finsemble": "https://assets.finsemble.com/dev/chartiq-finsemble-3.10.0.tgz",
         "@chartiq/finsemble-cli": "3.3.1",
         "@chartiq/finsemble-react-controls": "3.7.0",
         "async": "2.6.2",

--- a/package.json
+++ b/package.json
@@ -31,10 +31,10 @@
     "optionalDependencies": {
         "openfin-launcher": "1.3.12",
         "@chartiq/finsemble-cli": "3.3.1",
-        "@chartiq/finsemble-electron-adapter": "https://assets.finsemble.com/dev/chartiq-finsemble-electron-adapter-3.10.0.tgz"
+        "@chartiq/finsemble-electron-adapter": "3.9.0"
     },
     "dependencies": {
-        "@chartiq/finsemble": "https://assets.finsemble.com/dev/chartiq-finsemble-3.10.0.tgz",
+        "@chartiq/finsemble": "3.9.0",
         "@chartiq/finsemble-cli": "3.3.1",
         "@chartiq/finsemble-react-controls": "3.7.0",
         "async": "2.6.2",


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14653/details)

**Description of change**
* changed webpack.component.js to recursively search for finsemble.webpack.json

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Check out sales demo planned/3.10.0
1. cd in finsemble-seed and validate the branch for this ticket is the seed branch
1. cd back to sales demo root
1. run `npm i`
1. run `npm run build`
1. Compare _dist/components/authentication/authentication.js_ with the file in _src_ and _src-built-in_
1. [x] Validate that the output file was built from _src_ version.