### PR TITLE
fix: #id 14144 workspace save without user input causes logger error

### DIFF
--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -551,7 +551,7 @@ Actions = {
 				showNegativeButton: false,
 				showCancelButton: false
 			};
-			Actions.spawnDialog("yesNo", dialogParams);
+			Actions.spawnDialog("yesNo", dialogParams, Function.prototype);
 			return callback(new Error("Invalid workspace name."));
 		} else if (response.choice === 'cancel') {
 			return callback(new Error(SAVE_DIALOG_CANCEL_ERROR));


### PR DESCRIPTION
fix: #id 14144
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14144/details/)

**Description of change**
* spawnDialog is expecting a callback as the third parameter, pass in the function prototype as callback since we don't need to log anything for the user input in this case.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Pull down this branch, test along with planned/3.11.0
1. Create a workspace and click "save as", when the dialog prompt up for you to name the workspace, don't put in anything and click "confirm"
1. [x] Notice the logger will have the "invalid workspace name" error(which is useful and we want to keep that one) but no "userinput is not a function" error