### PR TITLE
fix: #id 14621 components created in the favorites folder get pinned

### DIFF
--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -334,6 +334,7 @@ function addApp(app = {}, cb) {
 		url: app.url,
 		type: "component"
 	};
+	const { FAVORITES } = getConstants();
 
 	FSBL.Clients.LauncherClient.addUserDefinedComponent(newAppData, (compAddErr) => {
 		if (compAddErr) {
@@ -342,6 +343,9 @@ function addApp(app = {}, cb) {
 			console.warn("Failed to add new app:", compAddErr);
 			return;
 		}
+		// If we're creating the app while in the favorites folder,
+		// we need to make sure it gets pinned to the toolbar
+		if (folder === FAVORITES) addPin({ name: app.name });
 		data.apps[appID] = newAppData;
 		data.folders[MY_APPS].apps[appID] = newAppData;
 		data.folders[folder].apps[appID] = newAppData;


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14621/details)

**Description of change**
* components created in the favorites folder get pinned

**Description of testing**
1. Go to favorites folder.
1. Add new app.
1. Observe app added to toolbar.

1. Go to custom folder.
1. Add new app.
1. Observe app not added to toolbar.