### PR TITLE
fix: #id 14688 app cant unpin when name changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "socket.io": "2.0.4",
         "strip-ansi": "3.0.1",
         "style-loader": "0.19.1",
+        "ts-loader": "^3.5.0",
         "tslint": "5.11.0",
         "typescript": "3.2.4",
         "uglifyjs-webpack-plugin": "1.2.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@chartiq/finsemble": "3.9.0",
         "@chartiq/finsemble-cli": "3.3.1",
-        "@chartiq/finsemble-react-controls": "^3.7.0",
+        "@chartiq/finsemble-react-controls": "3.7.0",
         "async": "2.6.2",
         "babel-minify-webpack-plugin": "0.3.1",
         "compression": "1.7.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dependencies": {
         "@chartiq/finsemble": "3.9.0",
         "@chartiq/finsemble-cli": "3.3.1",
-        "@chartiq/finsemble-react-controls": "3.7.0",
+        "@chartiq/finsemble-react-controls": "^3.7.0",
         "async": "2.6.2",
         "babel-minify-webpack-plugin": "0.3.1",
         "compression": "1.7.3",
@@ -78,7 +78,7 @@
         "socket.io": "2.0.4",
         "strip-ansi": "3.0.1",
         "style-loader": "0.19.1",
-        "ts-loader": "^3.5.0",
+        "ts-loader": "3.5.0",
         "tslint": "5.11.0",
         "typescript": "3.2.4",
         "uglifyjs-webpack-plugin": "1.2.7",

--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -223,7 +223,6 @@ var Actions = {
 		}
 
 		//No dots allowed in keys in the global store, so escaping dots
-		var componentTypeDotRemove = componentType.replace(/[.]/g, "^DOT^");
 
 		var pins = appLauncherStore.getValue("pins");
 		let params = { addToWorkspace: true, monitor: "mine" };
@@ -259,6 +258,8 @@ var Actions = {
 		if (!wasPinned) {
 			pins.push(thePin);
 		}
+
+		var componentTypeDotRemove = displayName.replace(/[.]/g, "^DOT^");
 
 		if (wasPinned) {
 			ToolbarStore.removeValue({ field: "pins." + componentTypeDotRemove });

--- a/src-built-in/components/toolbar/modules/pinManager.ts
+++ b/src-built-in/components/toolbar/modules/pinManager.ts
@@ -1,0 +1,92 @@
+/**
+ * This file handles component displayname changes and cases where
+ * components are no longer registered with finsemble.
+ * Given an array of pins and a component list, it'll do the work for you.
+ */
+declare type Pin = {
+	component?: string,
+	fontIcon: string,
+	icon: string,
+	index: number,
+	label: string,
+	params: {
+		addToWorkspace: Boolean,
+		monitor: string | number
+	}
+	toolbarSection: string
+	type: string
+	uuid: string
+}
+
+
+/**
+ * @todo handle dynamic component registration.
+ * @export
+ * @class PinManager
+ */
+export class PinManager {
+	/**
+	 * Converts the array of pins into an object where the key is the label
+	 * of the pin
+	 *
+	 * @param {Pin[]} arr
+	 * @returns any
+	 */
+	convertPinArrayToObject(arr: Pin[]): any {
+		let obj: any = {};
+		arr.forEach((el, i) => {
+			if (el) {
+				let key = el.label;
+				obj[key] = el;
+				obj[key].index = i;
+			}
+		});
+		return obj;
+	}
+
+	/**
+	 * Will rename the label of any component whose displayName changes between sessions.
+	 *
+	 * @param {*} componentList
+	 * @param {Pin[]} pins
+	 * @returns {Pin[]}
+	 * @memberof PinManager
+	 */
+	handleNameChanges(componentList: any, pins: Pin[]): Pin[] {
+		return pins.map((pin: Pin) => {
+			if (typeof pin.component === "undefined") return pin;
+
+			let componentConfig = componentList[pin.component];
+
+			let label = componentConfig.component.type;
+			if (componentConfig.component.displayName) {
+				label = componentConfig.component.displayName;
+			}
+
+			if (pin.label !== label) {
+				pin.label = label;
+			}
+
+			return pin;
+		})
+	}
+
+	/**
+	 * Returns a filtered list of pins where the members are valid, registered components (and
+	 * workspaces, if they're in the array)
+	 *
+	 * @param {*} componentList
+	 * @param {Pin[]} pins
+	 * @returns {Pin[]}
+	 * @memberof PinManager
+	 */
+	removePinsNotInComponentList(componentList: any, pins: Pin[]): Pin[] {
+		return pins.filter((pin: Pin) => {
+			if (typeof pin.component !== "undefined") {
+				return pin.component in componentList;
+			}
+			return true;
+		})
+	}
+
+}

--- a/src-built-in/components/toolbar/modules/pinManager.ts
+++ b/src-built-in/components/toolbar/modules/pinManager.ts
@@ -33,10 +33,10 @@ export class PinManager {
 	 * @returns any
 	 */
 	convertPinArrayToObject(arr: Pin[]): any {
-		let obj: any = {};
+		const obj: any = {};
 		arr.forEach((el, i) => {
 			if (el) {
-				let key = el.label;
+				const key = el.label;
 				obj[key] = el;
 				obj[key].index = i;
 			}
@@ -56,7 +56,7 @@ export class PinManager {
 		return pins.map((pin: Pin) => {
 			if (typeof pin.component === "undefined") return pin;
 
-			let componentConfig = componentList[pin.component];
+			const componentConfig = componentList[pin.component];
 
 			let label = componentConfig.component.type;
 			if (componentConfig.component.displayName) {

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -321,11 +321,6 @@ class _ToolbarStore {
 		async.series(
 			[
 				function (done) {
-					fin.desktop.System.showDeveloperTools(finsembleWindow.uuid, finsembleWindow.name, () => {
-						setTimeout(done, 2000)
-					});
-				},
-				function (done) {
 					self.createStores(done, self);
 				},
 				function (done) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"compilerOptions": {
-		"module": "system",
+		"target": "es2017",
+		"module": "commonjs",
 		"noImplicitAny": true,
 		"removeComments": true,
 		"preserveConstEnums": true,
@@ -8,7 +9,7 @@
 	},
 	"include": [
 		"src/**/*",
-		"src-built-in/preloads/*"
+		"src-built-in/**/*"
 	],
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14688/details)

**Description of change**
This PR makes it so that pins are renamed when the underlying component has a display name change. Additionally, if the component is removed from components.json, the pin will be excluded from the toolbar.

This PR also fixes tsconfig and ts-loader issue I had while working.

**Description of testing**
1. Load Finsemble on planned/3.10.0.  Pin a workspace and every component that is loaded. Switch to this branch and run `npm install`.
2. In components.json, change the component:displayName of Welcome Component to some other name.
3. In components.json, remove the Notepad entry.
4. Restart Finsemble.
5. Confirm that the pin for the Welcome Component has changed its name to whatever you named it to.
6. Confirm that the pin for Notepad is gone.
7. Unpin Welcome Component.
8. Restart Finsemble.
9. Confirm that the pin for Welcome Component is gone.
10. Add Notepad back.
11. Pin it.
12. Confirm that Notepad is pinned.
13. Restart.
14. Confirm that everything is the same.