### PR TITLE
fix: #id 14765 Forced webpack config to use / instead of \\

### DIFF
--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -63,8 +63,8 @@ listOfWebpackEntryFiles.forEach((filename) => {
 			additionalComponents[assetNoSuffix] = {
 				output: path.join(outputPath, assetNoSuffix).replace(/\\/g, "/"),
 				entry: `.${path.sep}${path.join(entryPath, assetName)}`.replace(/\\/g, "/")
-			};		
-		});		
+			};
+		});
 	} else {
 		// Otherwise assume it's already in object format (webpack.components.entries.json)
 		additionalComponents = entries;

--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -61,8 +61,8 @@ listOfWebpackEntryFiles.forEach((filename) => {
 			const assetNoSuffix = assetName.replace(/\.[^/.]+$/, ""); // Remove the .js or .jsx extension
 			const entryPath = path.relative(__homename, path.dirname(filename))
 			additionalComponents[assetNoSuffix] = {
-				output: path.join(outputPath, assetNoSuffix),
-				entry: `.${path.sep}${path.join(entryPath, assetName)}`
+				output: path.join(outputPath, assetNoSuffix).replace(/\\/g, "/"),
+				entry: `.${path.sep}${path.join(entryPath, assetName)}`.replace(/\\/g, "/")
 			};		
 		});		
 	} else {

--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -54,7 +54,6 @@ listOfWebpackEntryFiles.forEach((filename) => {
 	let entries = fs.existsSync(filename) ? require(filename) : {};
 
 	let additionalComponents = {};
-	console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", entries);
 	if (Array.isArray(entries)) {
 		// Process arrays (finsemble.webpack.json files) by automatically building the output & entry fields that webpack needs
 		entries.forEach((assetName) => {
@@ -64,8 +63,7 @@ listOfWebpackEntryFiles.forEach((filename) => {
 			additionalComponents[assetNoSuffix] = {
 				output: path.join(outputPath, assetNoSuffix).replace(/\\/g, "/"),
 				entry: `.${path.sep}${path.join(entryPath, assetName)}`.replace(/\\/g, "/")
-			};
-			console.log(additionalComponents[assetNoSuffix]);
+			};		
 		});		
 	} else {
 		// Otherwise assume it's already in object format (webpack.components.entries.json)

--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -54,6 +54,7 @@ listOfWebpackEntryFiles.forEach((filename) => {
 	let entries = fs.existsSync(filename) ? require(filename) : {};
 
 	let additionalComponents = {};
+	console.log("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", entries);
 	if (Array.isArray(entries)) {
 		// Process arrays (finsemble.webpack.json files) by automatically building the output & entry fields that webpack needs
 		entries.forEach((assetName) => {
@@ -63,7 +64,8 @@ listOfWebpackEntryFiles.forEach((filename) => {
 			additionalComponents[assetNoSuffix] = {
 				output: path.join(outputPath, assetNoSuffix).replace(/\\/g, "/"),
 				entry: `.${path.sep}${path.join(entryPath, assetName)}`.replace(/\\/g, "/")
-			};		
+			};
+			console.log(additionalComponents[assetNoSuffix]);
 		});		
 	} else {
 		// Otherwise assume it's already in object format (webpack.components.entries.json)


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14765/details)

**Description of change**
* Added regex replaces to change all \\ to /

**Description of testing**
1. Use the sales demo develop branch
1. check out the branch for this PR in the finsemble-seed submodule
1. Commit branch change to temporary branch (so install doesn't revert the change)
1. In the sales demo run `npm i`, then
1. `npm run build`
1. Examine files in the sales demo with _finsemble.webpack.json_ to verify that imports/requires are resolved by webpack.
- [x] dist\components\chartiq\chartiq.js
- [x] dist\components\salesforce\salesforceCommon.js
- [x] dist\components\salesforce\salesforceConnection.js
- [x] dist\components\salesforce\salesforceLogin.js
- [x] dist\components\salesforce\symphonySalesforcePlugin.js
- [x] dist\components\salesforce\opportunityList\opportunityList.js
- [x] dist\components\salesforce\accountList\accountList.js
- [x] dist\components\salesforce\contactList\contactList.js
- [x] dist\components\salesforce\detailPage\detailPage.js
- [x] dist\src\components\authentication\authentication.js
- [x] dist\components\researchExchange\rsrchx.js