### PR TITLE
Fix #14694 When a folder dragged over "My Apps" or "Favorites" move to the top of the list

### DIFF
--- a/src-built-in/components/myApps/src/components/FoldersList.jsx
+++ b/src-built-in/components/myApps/src/components/FoldersList.jsx
@@ -22,6 +22,8 @@ export default class FoldersList extends React.Component {
 			folderNameInput: '',
 			isNameError: false
 		}
+		// Reference to ontainer element of folder list
+		this.listDiv = React.createRef();
 		this.renameFolder = this.renameFolder.bind(this)
 		this.changeFolderName = this.changeFolderName.bind(this)
 		this.onFoldersListUpdate = this.onFoldersListUpdate.bind(this)
@@ -29,16 +31,40 @@ export default class FoldersList extends React.Component {
 		this.deleteFolder = this.deleteFolder.bind(this)
 		this.onFocusRemove = this.onFocusRemove.bind(this)
 		this.onDragEnd = this.onDragEnd.bind(this);
+		this.onMouseMove = this.onMouseMove.bind(this);
+		// The last known mouse Y position
+		this.mouseY = null;
+	}
+
+	/**
+	 * Keeps a track of the last mouse's clientY position
+	 * @param {MouseEvent} event The mouse move event
+	 */
+	onMouseMove(event) {
+		this.mouseY = event.clientY
 	}
 
 	onDragEnd(event = {}) {
-		if (!event.destination) return;
+		const listHeight = this.listDiv.current.clientHeight
+		const destination = event.destination || {};
+		// When mouseUp event fired outside of the list element
+		if (!destination.index) {
+			// When mouseUp high and outside the list 
+			if (this.mouseY < listHeight) {
+				destination.index = 0;
+			}
+			// When mouseUp below list or outside below the window
+			if (this.mouseY >= listHeight) {
+				destination.index = this.state.foldersList.length -1;
+			}
+		};
+		if (typeof destination.index === 'undefined') {
+			return;
+		}
 		//There are two items above the 0th item in the list. They aren't re-orderable. We add 2 to the index so that it matches with reality. The source comes in properly but the destination needs to be offset.
-		let newIndex = event.destination.index;
-
-		storeActions.reorderFolders(event.source.index, newIndex);
-
+		storeActions.reorderFolders(event.source.index, destination.index);
 	}
+
 	onAppDrop(event, folder) {
 		event.preventDefault()
 		const app = JSON.parse(event.dataTransfer.getData('app'))
@@ -91,10 +117,12 @@ export default class FoldersList extends React.Component {
 
 	componentWillMount() {
 		getStore().addListener({ field: 'appFolders.list' }, this.onFoldersListUpdate)
+		document.addEventListener('mousemove', this.onMouseMove);
 	}
 
 	componentWillUnmount() {
 		getStore().addListener({ field: 'appFolders.list' }, this.onFoldersListUpdate)
+		document.removeEventListener('mousemove', this.onMouseMove);
 	}
 
 	renameFolder(name, e) {
@@ -232,7 +260,7 @@ export default class FoldersList extends React.Component {
 	render() {
 		return (
 			<div className="top">
-				<div className='folder-list'>
+				<div className='folder-list' ref={this.listDiv}>
 					{this.renderUnorderableFolders()}
 					<FinsembleDnDContext onDragStart={this.onDragStart} onDragEnd={this.onDragEnd}>
 						<FinsembleDroppable direction="vertical" droppableId="folderList">


### PR DESCRIPTION
Fix #id [14694]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14694/details)

**Description of change**
* Track mouse Y position
* Move folder to the top/bottom of list based on mouseUp position

**Description of testing**

1. Check out this branch and switch to new app launcher `My Apps`
2. Start fresh and create 3-4 folders
3. Drag a folder from center or bottom all the way to the top or top outside the window
- [x] The folder becomes first in the list and below `My apps` and `Favorites`
4. Drag a folder from center or top all the way to the bottom or bottom outside the window
- [x] The folder becomes last in the folders list

`NOTE: When dragging the folder away from the window and releasing it, it will first return to where it was and then get to the top or bottom of the list, a limitation in current HTML5 drag and drop`

See screenshot for expected results.

![myapps-reorder folders](https://user-images.githubusercontent.com/1192143/60097239-a7877000-975b-11e9-8b70-6c9d91b2ece8.gif)
