### PR TITLE
14761-sort-of-app-launcher-results-failing

### DIFF
--- a/src-built-in/components/myApps/src/utils/sort-functions.js
+++ b/src-built-in/components/myApps/src/utils/sort-functions.js
@@ -2,13 +2,12 @@ import storeActions from '../stores/StoreActions'
 
 export default {
 	/**
-	 * Sorts list alphabetically
+	 * Sorts list by name alphabetically
 	 */
 	Alphabetical: (list) => {
-		return list.sort((a, b) => {
-			return a.name.toLowerCase() > b.name.toLowerCase()
-		})
+		return list.sort((a, b) => a.name.localeCompare(b.name));
 	},
+
 	/**
 	 * Sorts a list of application by Favorites.
 	 * It gets a list of apps from Favorites folder
@@ -17,9 +16,20 @@ export default {
 	 * for apps that are in Favorite folder
 	 */
 	Favorites: (list) => {
-		const favorites = storeActions.getSingleFolder('Favorites').apps
+		const favorites = storeActions.getSingleFolder('Favorites').apps;
 		return list.sort((a, b) => {
-			return Boolean(favorites[a.appID]) < Boolean(favorites[b.appID])
-		})
+			const aInFavorites = a.appID in favorites;
+			const bInFavorites = b.appID in favorites;
+			// a component being in favorites means it is "less than" another component not in favorites, so return -1
+			if (aInFavorites && !bInFavorites) 
+			{
+				return -1;
+			}
+			else if (!aInFavorites && bInFavorites)
+			{
+				return 1;
+			}
+			return a.name.localeCompare(b.name);
+		});
 	}
 }


### PR DESCRIPTION
fix #id [14761]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14761/details)

**Description of change**
Fixing the sort function for the app launcher menu.

**Description of testing**
1. Enable the new app launcher in the toolbar config
1. Replace components.json with this file: https://drive.google.com/file/d/19ssaktqO4y0aRFgWcdtTFD3ZpDq0otRj/view
1. Load Finsemble with clean storage
1. Open the My Apps menu
1. Add some components to Favorites.
1. Select sorting by "Alphabetic".
1. Confirm that, when "Alphabetic" sorting is selected, the components are sorted by name alphabetically.
1. Select sorting by "Favorites".
1. Confirm that, when "Favorites" sorting is selected, the components are sorted by whether they are in favorites (favorites come first) and then by name alphabetically.
