### PR TITLE
14675 Change write to component state to storage

### DIFF
--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -232,17 +232,11 @@ class _ToolbarStore {
 	 * @memberof _ToolbarStore
 	 */
 	onBlur(cb = Function.prototype) {
-		finsembleWindow.setComponentState({
-			field: 'blurred',
-			value: true
-		}, cb);
+		FSBL.Clients.StorageClient.save({ topic: finsembleWindow.name, key: 'blurred', value: true }, cb);
 	}
 
 	onFocus(cb = Function.prototype) {
-		finsembleWindow.setComponentState({
-			field: 'blurred',
-			value: false
-		}, cb);
+		FSBL.Clients.StorageClient.save({ topic: finsembleWindow.name, key: 'blurred', value: false }, cb);
 	}
 
 	/**


### PR DESCRIPTION
fix: #14675 [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14675/details)

**Description of change**
* Changes blurred state write to storage instead of workspace (component state)

**Description of testing**
1. Paired with core branch: https://github.com/ChartIQ/finsemble/pull/1382
1. Run finsemble
1. Ensure toolbar is claiming space (assuming default config)
1. Undock and move toolbar, restart
1. [ ] Toolbar restored in previous place
1. Redock then restart
1. The toolbar should still be claiming space on restart
1. [ ] Space was correctly claimed