### PR TITLE
chore: remove icon support from window tabs

### DIFF
--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -321,6 +321,7 @@ html.desktop-active .fsbl-linker[hover=true] {
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+	  padding-left: 8px;
 }
 
 .fsbl-tab-close {

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -3,7 +3,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import Tab from "./tab";
-import Logo from "./logo";
 import { FinsembleHoverDetector } from "@chartiq/finsemble-react-controls";
 import { FinsembleDnDContext, FinsembleDroppable } from '@chartiq/finsemble-react-controls';
 import { Store, Actions } from "../../stores/windowTitleBarStore";
@@ -547,7 +546,6 @@ function renderTitle() {
         data-hover={this.state.hoverState}
         className={"fsbl-header-title"}>
         <FinsembleHoverDetector edge="top" hoverAction={this.hoverAction.bind(this)} />
-        <Logo windowIdentifier={FSBL.Clients.WindowClient.getWindowIdentifier()} />
         <Title onUpdate={this.props.onTitleUpdated} windowIdentifier={FSBL.Clients.WindowClient.getWindowIdentifier()}></Title>
     </div>);
 }

--- a/src-built-in/components/windowTitleBar/src/components/center/logo.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/logo.jsx
@@ -1,3 +1,9 @@
+/**
+ * This file is no longer used in Finsemble 3.x as of 3.10.
+ * It is left in place in case any external developers are directly referencing it.
+ * This avoids having a completely broken build on upgrading.
+ */
+
 import React from "react";
 export default class Logo extends React.PureComponent {
 	constructor(props) {

--- a/src-built-in/components/windowTitleBar/src/components/center/tab.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/tab.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { FinsembleHoverDetector } from "@chartiq/finsemble-react-controls";
 import { FinsembleDraggable } from "@chartiq/finsemble-react-controls";
-import Logo from "./logo";
 import Title from "../../../../common/windowTitle"
 /**
  * This component is pretty basic. It just takes a bunch of props and renders them.
@@ -71,7 +70,6 @@ export default class Tab extends React.Component {
 					></div>
 				}
 				<FinsembleHoverDetector edge="top" hoverAction={this.hoverAction.bind(this)} />
-				<Logo windowIdentifier={this.props.windowIdentifier} />
 				<Title titleWidth={this.props.titleWidth} windowIdentifier={this.props.windowIdentifier} />
 				<div className="fsbl-tab-close" onClick={(e) => {
 					e.preventDefault();


### PR DESCRIPTION
The logo code for tabs has been broken for quite a while.
Upon triaging it to get them back, all kinds of weird state
isolation problems were appearing.

It was decided that rather than address all of this now in 3.x
we will remove what functionality was left of it for this series.
For the ux refresh in 4.x this will be revisited and brought back
in a properly functioning way.

To account for the logo element no longer being in the DOM, which
was giving some space in between the divider and title. We now
have a fixed padding of 8px on the left of the title text.
This prevents the text from directly touching the divider visually.

https://chartiq.kanbanize.com/ctrl_board/18/cards/14738/details/

**Description of testing**

Do keep the Central Logger open and set to "Errors only" to verify along the way that no errors crop up from removing the logo.

VERIFY - Means checking no logos are in the window's tabs and that the title text is not touching the divider

1. Run Finsemble
1. VERIFY against the default welcome component
1. Open a new welcome component
1. VERIFY against the newly spawned component
1. Stack the two windows
1. VERIFY against the stack
1. Open a Process Monitor
1. VERIFY the process monitor
1. Add the process monitor to the stack
1. VERIFY the stack
1. Re-order the tabs in the stacked window
1. VERIFY the stack