### PR TITLE
Change Linker Window name

### DIFF
--- a/src-built-in/components/linker/linker.html
+++ b/src-built-in/components/linker/linker.html
@@ -10,7 +10,7 @@
 
 <head>
     <script src="../../vendor.bundle.js"></script>
-    <title>Linker Window</title>
+    <title>Finsemble Linker Window</title>
 </head>
 
 <body>


### PR DESCRIPTION
fix: #id 14897

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14897/details/)

**Description of change**
Changed linker window name in HTML so that assimilation name for window in focus event matches container name for window (Brad identified this anomaly).  

**Description of testing**
*Test on OpenFin Container*
1. Bring up multiple welcome components
1. Click on linker icon to bring up linker window in each.  The linker window should stay up as long as it maintains focus (i.e. until click outside of linker window). 
