### PR TITLE
14689-Dragging-a-tab-can-cause-central-logger-erro

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -556,13 +556,13 @@ function renderTitle() {
  */
 function renderTabs() {
     let titleWidth = this.state.tabWidth - ICON_AREA - CLOSE_BUTTON_MARGIN;
-    return this.state.tabs.map((tab, i) => {
+    return this.state.tabs.map(tab => {
         return <Tab
             onClick={() => {
                 this.setActiveTab(tab);
             }}
             draggable="true"
-            key={i}
+            key={tab.windowName} //this is a unique identifier for React so it knows when to update the DOM
             className={this.getTabClasses(tab)}
             onDragStart={(e, identifier) => {
                 FSBL.Clients.Logger.system.debug("Tab drag - TAB", identifier.windowName);


### PR DESCRIPTION
fix #id [14689]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/14689/CARD/details)

**Description of change**

We need to ensure that the key attribute in React components is unique to that component and will not change.  This helps React determine whether to update the DOM or not.

The error that was observed in central logger was a result of the incorrect tab(s) being updated because the key was the index in the list of tabs, which caused React to think that a tab that had been moved did not need to be re-rendered when in fact it did, and that a tab that had not been moved needed to be re-rendered when it fact it did not.

Given the right sequence of actions, this resulted in componentWillUnmount being called on a component which had not received a componentWillMount call, hence the error described in the Kanban ticket.

This fix changes the key for tabs to be the windowName, which I am fairly certain is a unique identifier for the Finsemble component.

**Description of testing**

Note that these specific steps were done using Electron, Win 10, and 3.10.0.  This is what was done to consistently reproduce.  The mp4 attachment on the Kanban card card also demonstrates these steps.

1. Spawn three new components - component 1, component 2, and component 3.

2. Drag the title text of component 2 to the right of component 1's title text so that component 2 is now a tab in component 1's window.

3. Drag the title text of component 3 just to the right of component 1's title text so that component 3 is now in between component 1's tab and component 2's tab.

4. Drag the title text of component 2, which should be the rightmost tab, onto the desktop.

5. Confirm there are no errors in central logger.
