### PR TITLE
14562 Cross domain breaks tabbing

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
+++ b/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
@@ -116,22 +116,33 @@ export default class TabRegion extends React.Component {
 	 * @memberof windowTitleBar
 	 */
     stopDrag(e) {
-        FSBL.Clients.Logger.system.debug("Tab drag stop");
-        //@sidd can you document this?
+        FSBL.Clients.Logger.system.debug("Tab stopDrag.");
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,
             y: e.nativeEvent.screenY
         }
-        let boundingRect = this.state.boundingBox;
-        if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, FSBL.Clients.WindowClient.options)) {
-            setTimeout(() => {
-                FSBL.Clients.WindowClient.stopTilingOrTabbing({ mousePosition: this.mousePositionOnDragEnd });
-            }, 50);
-            this.setState({
-                iAmDragging: false
-            });
-            this.onWindowResize();
-        }
+        
+        const boundingBox = this.state.boundingBox;
+        FSBL.Clients.WindowClient.getBounds(
+            (err, bounds) => {
+                // We ONLY want to know if we're in the tab region!
+                const tabRegion = {
+                    top: boundingBox.top + bounds.top,
+                    bottom: boundingBox.bottom + bounds.top,
+                    left: boundingBox.left + bounds.left,
+                    right: boundingBox.right + bounds.left 
+                };
+                if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, tabRegion)) {
+                    setTimeout(() => {
+                        FSBL.Clients.WindowClient.stopTilingOrTabbing({ mousePosition: this.mousePositionOnDragEnd });
+                    }, 50);
+                    this.setState({
+                        iAmDragging: false
+                    });
+                    this.onWindowResize();
+                }
+            }
+        );
     }
 
     /**

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -125,13 +125,23 @@ export default class TabRegion extends React.Component {
 	 * @memberof windowTitleBar
 	 */
     stopDrag(e) {
+        FSBL.Clients.Logger.system.debug("Tab stopDrag.");
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,
             y: e.nativeEvent.screenY
         }
+        
+        const boundingBox = this.state.boundingBox;
         FSBL.Clients.WindowClient.getBounds(
             (err, bounds) => {
-                if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, bounds)) {
+                // We ONLY want to know if we're in the tab region!
+                const tabRegion = {
+                    top: boundingBox.top + bounds.top,
+                    bottom: boundingBox.bottom + bounds.top,
+                    left: boundingBox.left + bounds.left,
+                    right: boundingBox.right + bounds.left 
+                };
+                if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, tabRegion)) {
                     setTimeout(() => {
                         FSBL.Clients.WindowClient.stopTilingOrTabbing({ mousePosition: this.mousePositionOnDragEnd });
                     }, 50);
@@ -140,7 +150,7 @@ export default class TabRegion extends React.Component {
                     });
                     this.onWindowResize();
                 }
-            } 
+            }
         );
     }
 

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -125,22 +125,23 @@ export default class TabRegion extends React.Component {
 	 * @memberof windowTitleBar
 	 */
     stopDrag(e) {
-        FSBL.Clients.Logger.system.debug("Tab drag stop");
-        //@sidd can you document this?
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,
             y: e.nativeEvent.screenY
         }
-        let boundingRect = this.state.boundingBox;
-        if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, FSBL.Clients.WindowClient.options)) {
-            setTimeout(() => {
-                FSBL.Clients.WindowClient.stopTilingOrTabbing({ mousePosition: this.mousePositionOnDragEnd });
-            }, 50);
-            this.setState({
-                iAmDragging: false
-            });
-            this.onWindowResize();
-        }
+        FSBL.Clients.WindowClient.getBounds(
+            (err, bounds) => {
+                if (!FSBL.Clients.WindowClient.isPointInBox(this.mousePositionOnDragEnd, bounds)) {
+                    setTimeout(() => {
+                        FSBL.Clients.WindowClient.stopTilingOrTabbing({ mousePosition: this.mousePositionOnDragEnd });
+                    }, 50);
+                    this.setState({
+                        iAmDragging: false
+                    });
+                    this.onWindowResize();
+                }
+            } 
+        );
     }
 
     /**


### PR DESCRIPTION
fix: #id [14562]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14562/details)

**Get  proper bounding rect on drag stop**
* Previously, the code for stopDrag was using the "options" for the window component and not getting the actual bounding box for the current component state. Code was updated to use the getBounds() method for returning the bounding box.

Code for blank component in components.json:

```
		"BlankComponent": {
			"window": {
				"url": "https://finsemble.chartiq.com/components/system/blankComponent/index.html",
				"width": 660,
				"height": 410
			},
			"component": {
				"mode": "premium",
				"category": "system"
			},
			"foreign": {
				"services": {
					"dockingService": {
						"isArrangable": true
					}
				},
				"components": {
					"App Launcher": {
						"launchableByUser": true
					},
					"Toolbar": {
						"iconClass": "ff-chart-pie"
					},
					"Window Manager": {
						"FSBLHeader": true,
						"showLinker": true,
						"persistWindowState": true
					}
				}
			}
		},
```

Use secure IAC:

```
"IAC": {
    "serverAddress": "wss://localhost.chartiq.com:3376"
}
```

**Description of testing**

1. Create blank component config in components.json. Verify that IAC address is correct.
1. Start finsemble
1. Tab blank component onto a freshly spawned Welcome component.
1. Try to untab blank component by dropping it in it's original spawn location
1. Blank component untabs and mouse drag is properly stopped. No scrims show over other windows.