### PR TITLE
Filling in the blanks for AutoHide 

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -412,7 +412,7 @@ class WindowTitleBar extends React.Component {
 				</div>
 				<div className={rightWrapperClasses} ref={this.setToolbarRight}>
 					{this.state.alwaysOnTopButton && showMinimizeIcon ? <AlwaysOnTop /> : null}
-					{this.state.autoHideButton && showMinimizeIcon ? <AutoHide /> : null}
+					{this.state.autoHideButton ? <AutoHide /> : null}
 					<BringSuiteToFront />
 					{this.state.minButton && showMinimizeIcon ? <Minimize /> : null}
 					{showDockingIcon ? <DockingButton /> : null}


### PR DESCRIPTION
 + only suspending autoHide when it's enabled on the component.

recipe: #id [13795]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13795/details/)

**Description of change**
* Filled in the blanks
* Only suspend the auto hide on drag if the component has it enabled.

**Description of testing**
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 
1. Untab the component
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 
1. Tab the component again into the other component
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 

