### PR TITLE
Auto-hiding window chrome bug

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/right/AutoHide.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/right/AutoHide.jsx
@@ -4,8 +4,7 @@
 */
 import React from "react";
 import { FinsembleHoverDetector } from "@chartiq/finsemble-react-controls";
-import { getStore, Actions as HeaderActions } from "../../stores/windowTitleBarStore";
-let windowTitleBarStore;
+import { Actions as HeaderActions } from "../../stores/windowTitleBarStore";
 
 /**
  * Auto-hide window chrome toggle button.

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -8,12 +8,10 @@ var windowTitleBarStore;
 var WindowClient;
 import windowTitleBarStoreDefaults from "./windowTitleBarStoreDefaults";
 import * as async from "async";
-var finWindow = fin.desktop.Window.getCurrent();
 
 //autohide functions and timers
 let headerTimeout = null;
 let suspendAutoHide = false;
-let autohideTimeout = 2000;
 let autohideSavedBodyMargin = null;
 const autoHideDefaultConfig = {
 	defaultSetting: false,
@@ -219,7 +217,7 @@ var Actions = {
 				autoHideConfig = Object.assign(autoHideDefaultConfig, autoHideIcon);
 			} /* else { defaults apply } */
 			windowTitleBarStore.setValues([{ field: "AutoHide.show", value: showAutoHide }]);
-			FSBL.Clients.Logger.log("Autohide window chrome settings: ", autoHideConfig) 
+			FSBL.Clients.Logger.log("Autohide window chrome settings: ", autoHideConfig)
 
 			//If tabbing is turned off, ignore global/local 'windowManager' config about whether to allow tabbing.
 			if (dockingConfig.tabbing.enabled === false) {
@@ -475,7 +473,7 @@ var Actions = {
  		//preserve the body margin so we can remove and restore it
 		if (!autohideSavedBodyMargin){
 			autohideSavedBodyMargin = document.body.style.marginTop;
-		} 
+		}
 
  		if (autoHide){
 			let header = document.getElementsByClassName("fsbl-header")[0];
@@ -519,14 +517,24 @@ var Actions = {
  		cb();
 	},
 	suspendAutoHide(suspend) {
-		suspendAutoHide = suspend;
-		if (suspendAutoHide) {
-			let header = document.getElementsByClassName("fsbl-header")[0];
-			header.style.opacity = 1;
-			if (headerTimeout) {clearTimeout(headerTimeout);}
-		} else {
-			autoHideTimer();
-		}
+		FSBL.Clients.WindowClient.getComponentState({"field": "autoHide"}, (err, isAutoHideEnabled) => {
+			if (err || isAutoHideEnabled === null) {
+				isAutoHideEnabled = autoHideConfig.defaultSetting;
+			}
+
+			if (isAutoHideEnabled) {
+				suspendAutoHide = suspend;
+				if (suspendAutoHide) {
+					let header = document.getElementsByClassName("fsbl-header")[0];
+					header.style.opacity = 1;
+					if (headerTimeout) {
+						clearTimeout(headerTimeout);
+					}
+				} else {
+					autoHideTimer();
+				}
+			}
+		});
 	},
 	getTabs() {
 		return windowTitleBarStore.getValue({ field: "tabs" });

--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -428,7 +428,7 @@ class WindowTitleBar extends React.Component {
 				</div>
 				<div className={rightWrapperClasses} ref={this.setToolbarRight}>
 					{this.state.alwaysOnTopButton && showMinimizeIcon ? <AlwaysOnTop /> : null}
-					{this.state.autoHideButton && showMinimizeIcon ? <AutoHide /> : null}
+					{this.state.autoHideButton ? <AutoHide /> : null}
 					<BringSuiteToFront />
 					{this.state.minButton && showMinimizeIcon ? <Minimize /> : null}
 					{showDockingIcon ? <DockingButton /> : null}


### PR DESCRIPTION

recipe: #id [13795]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/13795/details/)

**Description of change**
* Only suspend the auto hide on drag if the component has it enabled.

**Description of testing**
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 
1. Untab the component
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 
1. Tab the component again into the other component
1. Open 3 welcome components
1. Set auto hide to off on one and on on the other
1. [x] AutoHide works according to the setting set on the respective windows
1. Tab the 3rd component into one of the other
1. [x] AutoHide still works according to the setting set on the respective windows 