### PR TITLE
Fix 15127 My Apps is vulnerable to components with invalid config

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "file-loader": "1.1.11",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
+        "lodash.get": "^4.4.2",
         "lodash.throttle": "4.1.1",
         "nocache": "2.0.0"
     },

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -1,3 +1,4 @@
+import _get from 'lodash.get';
 import { getStore } from "./LauncherStore";
 import AppDirectory from "../modules/AppDirectory";
 import FDC3 from "../modules/FDC3";
@@ -175,12 +176,7 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 			// If the app is already in our list move on
 			if (appInAppList(componentName)) return;
 			const component = componentList[componentName];
-			let launchableByUser;
-			try {
-				launchableByUser = component.foreign.components["App Launcher"].launchableByUser;
-			} catch (error) {
-				launchableByUser = false
-			}
+			const launchableByUser = _get(component, 'foreign.components.App Launcher.launchableByUser');
 			// Make sure the app is launchable by user
 			if (launchableByUser) {
 				data.configComponents[componentName] = {

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -174,9 +174,15 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 		componentNameList.map(componentName => {
 			// If the app is already in our list move on
 			if (appInAppList(componentName)) return;
-			let component = componentList[componentName];
+			const component = componentList[componentName];
+			let launchableByUser;
+			try {
+				launchableByUser = component.foreign.components["App Launcher"].launchableByUser;
+			} catch (error) {
+				launchableByUser = false
+			}
 			// Make sure the app is launchable by user
-			if (component.foreign.components && component.foreign.components["App Launcher"] && component.foreign.components["App Launcher"].launchableByUser) {
+			if (launchableByUser) {
 				data.configComponents[componentName] = {
 					appID: componentName,
 					icon: component.foreign.Toolbar && component.foreign.Toolbar.iconClass ? component.foreign.Toolbar.iconClass : null,


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15127/details)

**Description of change**
* Catch exception when thrown during access of non existing `launchableByUser`

**Description of testing**
1. Check out this branch run `npm run dev`
1. Editing toolbar/config.json line 50 set menuType to `My Apps`
1. Edit components.json remove `foreign` key from Welcome Component
1. Run the seed `npm run dev`
- [x] My Apps launcher still works
- [x] Welcome components is not there
- [x] No My Apps errors in central logger