### PR TITLE
Set up close request confirmation dialog when user right clicks to close finsemble toolbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "@chartiq/finsemble-react-controls": "3.7.0",
         "async": "2.6.2",
         "babel-minify-webpack-plugin": "0.3.1",
-        "lodash.get": "^4.4.2",
+        "lodash.get": "4.4.2",
         "compression": "1.7.3",
         "file-loader": "1.1.11",
         "lodash.clonedeep": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@chartiq/finsemble-react-controls": "3.7.0",
         "async": "2.6.2",
         "babel-minify-webpack-plugin": "0.3.1",
+        "lodash.get": "^4.4.2",
         "compression": "1.7.3",
         "file-loader": "1.1.11",
         "lodash.clonedeep": "4.5.0",

--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -6,14 +6,21 @@
 // Static vs Dynamic Toolbar
 import Toolbar from "./dynamicToolbar";
 // import Toolbar from "./staticToolbar";
-//Band-aid. Openfin not respecting small bounds on startup.
-if (!fin.container || fin.container != "electron") {
-  fin.desktop.main(() => {
-    let finWindow = fin.desktop.Window.getCurrent();
+
+function FSBLReady() {
+  //Band-aid. Openfin not respecting small bounds on startup.
+  if (!FSBL.System.container || FSBL.System.container != "electron") {
+    let finWindow = FSBL.System.Window.getCurrent();
     finWindow.getOptions((opts) => {
       if (opts.smallWindow) {
         finWindow.setBounds(opts.defaultLeft, opts.defaultTop, opts.defaultWidth, opts.defaultHeight);
       }
     })
-  })
+  }
+}
+
+if (window.FSBL && FSBL.addEventListener) {
+  FSBL.addEventListener("onReady", FSBLReady);
+} else {
+  window.addEventListener("FSBLReady", FSBLReady);
 }

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -227,7 +227,7 @@ class _ToolbarStore {
 			self.hideToolbar();
 		});
 
-		fin.desktop.Window.getCurrent().addEventListener("close-requested", () => this.closeRequestedHandler());
+		FSBL.System.Window.getCurrent().addEventListener("close-requested", () => this.closeRequestedHandler());
 	}
 
 	/**

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -235,6 +235,8 @@ class _ToolbarStore {
 	 */
 	async closeRequestedHandler() {
 		const args = await this.confirmCloseToolbar();
+		// proceed even if there is an error in case the user selected to shut down. Shut down despite error.
+		// do nothing if there was an error or they chose cancel.
 		if (args.err) {
 			Logger.system.log(`Error received on confirm close: ${args.err} Continuing.`);
 		}

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -240,7 +240,8 @@ class _ToolbarStore {
 		if (args.err) {
 			Logger.system.log(`Error received on confirm close: ${args.err} Continuing.`);
 		}
-		if (args.result.choice === 'affirmative') {
+		const choice = _get(args, 'result.choice');
+		if (choice === 'affirmative') {
 			fin.desktop.Window.getCurrent().close(true);
 			FSBL.shutdownApplication();
 		}

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -5,6 +5,7 @@
 import async from "async";
 import * as menuConfig from '../config.json';
 import * as storeExports from "../stores/searchStore";
+import _get from 'lodash.get';
 import { PinManager } from "../modules/pinManager"
 import { Actions as SearchActions } from "./searchStore"
 const PinManagerInstance = new PinManager();
@@ -238,7 +239,7 @@ class _ToolbarStore {
 		// proceed even if there is an error in case the user selected to shut down. Shut down despite error.
 		// do nothing if there was an error or they chose cancel.
 		if (args.err) {
-			Logger.system.log(`Error received on confirm close: ${args.err} Continuing.`);
+			Logger.system.log(`Error received on confirm close: ${args.err}. Continuing.`);
 		}
 		const choice = _get(args, 'result.choice');
 		if (choice === 'affirmative') {
@@ -305,7 +306,8 @@ class _ToolbarStore {
 			title: "Confirm Shutdown",
 			question: "Do you wish to shut down finsemble?",
 			affirmativeResponseLabel: "Shut down",
-			negativeResponseLabel: "Cancel"
+			negativeResponseLabel: "Cancel",
+			showCancelButton: false,
 		};
 		return new Promise(resolve => {
 			FSBL.Clients.DialogManager.open("yesNo", dialogParams, (err, result) => resolve({ err, result }));

--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -243,7 +243,7 @@ class _ToolbarStore {
 		}
 		const choice = _get(args, 'result.choice');
 		if (choice === 'affirmative') {
-			fin.desktop.Window.getCurrent().close(true);
+			FSBL.System.Window.getCurrent().close(true);
 			FSBL.shutdownApplication();
 		}
 	}


### PR DESCRIPTION
feat: #id [12600](https://chartiq.kanbanize.com/ctrl_board/18/cards/12600/details/)

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/12600/details)

**Description of change**
* Adds a close confirmation dialog when a user right clicks to close finsemble toolbar. Previously there was no dialog, and choosing close would close the toolbar (with no way of getting it back). 

**Description of testing**
1. Checkout `planned/4.0.0` in `finsemble` and `finsemble-electron-adapter`
2. Checkout `12600-toolbar-close-confirm` in `finsemble-seed`
3. Launch finsemble
4. Right click the left hand side of the finsemble toolbar

![image](https://user-images.githubusercontent.com/45185091/62483104-c2da9780-b76b-11e9-94bf-4d70994f91cb.png)

5. Choose close
6. A dialog should appear. Test both cases.

-> Clicking cancel should do nothing
-> Clicking Shut down should should down finsemble

![image](https://user-images.githubusercontent.com/45185091/62877611-43554700-bcdc-11e9-9852-a8d4b3c8724b.png)

