### PR TITLE
15475 - Toolbar bringtofront on hotkey

### DIFF
--- a/src-built-in/components/toolbar/stores/toolbarStore.js
+++ b/src-built-in/components/toolbar/stores/toolbarStore.js
@@ -239,7 +239,7 @@ class _ToolbarStore {
 			});
 			FSBL.Clients.HotkeyClient.addGlobalHotkey([keys.ctrl, keys.alt, keys.f], (err) => {
 				if (err) { FSBL.Clients.Logger.error(`HotkeyClient.addGlobalHotkey failed, error:`, err); }
-				self.Store.setValue({ field: "searchActive", value: true });
+				this.bringToolbarToFront(true);
 			});
 		}
 		return cb();


### PR DESCRIPTION
fix: #id [15475]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15475/details)

**Changed hotkey handler to "bringToolbarToFront"**
* Previous hotkey handler activated the search box but did not bring toolbar to front. This call has been updated.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Run finsemble
1. Put finsemble toolbar behind a native window. (Explorer, chrome, etc...)
1. Press Ctrl + Alt + F
1. [ ] Toolbar is properly brought to front over non-finsemble windows.
