### PR TITLE
14512 TilingStop on tabbing cancel

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -254,8 +254,9 @@ class WindowTitleBar extends React.Component {
 		//Add an event listener to hide the drag-handler when tiling is started
 		FSBL.Clients.RouterClient.addListener("DockingService.startTilingOrTabbing", this.onTilingStart);
 
-		//Add an event listener to show the drag-handler when tiling is stopped
+		//Add an event listener to show the drag-handler when tiling is stopped or cancelled
 		FSBL.Clients.RouterClient.addListener("DockingService.stopTilingOrTabbing", this.onTilingStop);
+		FSBL.Clients.RouterClient.addListener("DockingService.cancelTilingOrTabbing", this.onTilingStop);
 	}
 
 	/**


### PR DESCRIPTION
fix: #id [14512]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14512/details)

**TilingStop on Tabbing Cancel**
* The core PR fixes the drop targets. However, MikeM discovered that we still had issues when dropping on the titlebar. When we start tabbing, the drag handle gets hidden. This code update will have the titlebar listen for the cancel event as well as the stop event so that the drag handle will be unhidden and the window can be moved again after we cancel tiling or tabbing.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Run finsemble with both PR's.
1. For this one, drop the tab back on it's own titlebar, or itself and make sure the window is still draggable afterwards.