### PR TITLE
feat: #id [16093] Allow for custom components in toolbar

### DIFF
--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -17,3 +17,12 @@ if (!fin.container || fin.container != "electron") {
     })
   })
 }
+
+if (window.FSBL && FSBL.addEventListener) {
+	FSBL.addEventListener("onReady", FSBLReady);
+} else {
+	window.addEventListener("FSBLReady", FSBLReady);
+}
+function FSBLReady() {
+	Toolbar.initialise();
+}

--- a/src-built-in/components/toolbar/src/dynamicToolbar.jsx
+++ b/src-built-in/components/toolbar/src/dynamicToolbar.jsx
@@ -20,28 +20,29 @@ import WorkspaceMenuOpener from "../components/WorkspaceMenuOpener"
 import Search from "../components/Search"
 import DragHandle from "../components/DragHandle"
 
-// Support Dynamically Loading External Components
-var customComponents = [];
-customComponents["AutoArrange"] = AutoArrange;
-customComponents["AlwaysOnTop"] = AlwaysOnTop;
-customComponents["BringToFront"] = BringToFront;
-customComponents["MinimizeAll"] = MinimizeAll;
-customComponents["WorkspaceMenuOpener"] = WorkspaceMenuOpener;
-customComponents["Search"] = Search;
 
 // Styles
 import "../toolbar.css";
 import "../../../../assets/css/font-finance.css";
 import "../../../../assets/css/finsemble.css";
 
-var pinnableItems = {
-	"componentLauncher": FinsembleButton,
-	"workspaceSwitcher": WorkspaceLauncherButton
-};
-
 export default class Toolbar extends React.Component {
 	constructor(props) {
 		super(props);
+		// Able to load external components by overriding the class
+		this.customComponents = [];
+		this.customComponents["AutoArrange"] = AutoArrange;
+		this.customComponents["AlwaysOnTop"] = AlwaysOnTop;
+		this.customComponents["BringToFront"] = BringToFront;
+		this.customComponents["MinimizeAll"] = MinimizeAll;
+		this.customComponents["WorkspaceMenuOpener"] = WorkspaceMenuOpener;
+		this.customComponents["Search"] = Search;
+
+		this.pinnableItems = {
+			"componentLauncher": FinsembleButton,
+			"workspaceSwitcher": WorkspaceLauncherButton
+		};
+
 		this.state = {
 			sections: ToolbarStore.getSectionsFromMenus(),
 			finWindow: fin.desktop.Window.getCurrent(),
@@ -135,7 +136,7 @@ export default class Toolbar extends React.Component {
 						buttonComponent = <FinsembleToolbarSeparator key={i} />;
 						break;
 					case "reactComponent":
-						let Component = customComponents[button.reactComponent];
+						let Component = this.customComponents[button.reactComponent];
 						buttonComponent = <Component key={i} {...button} className={"finsemble-toolbar-button"} />;
 						break;
 					case "workspaceSwitcher":
@@ -163,7 +164,7 @@ export default class Toolbar extends React.Component {
 				arrangeable={sectionPosition === "center"}
 				ref="pinSection"
 				name={sectionPosition}
-				pinnableItems={pinnableItems}
+				pinnableItems={this.pinnableItems}
 				className={sectionPosition}
 				key={sectionPosition}
 				handleOverflow={sectionPosition === "center"}
@@ -185,17 +186,13 @@ export default class Toolbar extends React.Component {
 		</FinsembleToolbar>);
 	}
 
-}
-
-if (window.FSBL && FSBL.addEventListener) {
-	FSBL.addEventListener("onReady", FSBLReady);
-} else {
-	window.addEventListener("FSBLReady", FSBLReady);
-}
-function FSBLReady() {
-	ToolbarStore.initialize(function () {
-		ReactDOM.render(
-			<Toolbar />
-			, document.getElementById("toolbar_parent"));
-	});
+	static initialise() {
+		// Class can be extended so `this` instead of `Toolbar` to get correct class type
+		const Component = this;
+		ToolbarStore.initialize(function () {
+			ReactDOM.render(
+				<Component />
+				, document.getElementById("toolbar_parent"));
+		});
+	}
 }


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/16093/details/)

**Description of change**
Allow the `customComponents` (and `pinnableItems`) variable to be modified by React components that extend the Toolbar component.

Prevent initialisation from occurring when including the file by moving runnable code into app.jsx (separating the library from the execution)

**Description of testing**
1. Check out the branch.
1. Run it (install, etc)
1. Make sure the toolbar still operates as expected.

This allows for adding custom react components to the Toolbar by 

_scr/components/customToolbar/finsemble.webpack.json_
```
{
    "customToolbar": {
        // This will replace the exiting toolbar output with the custom one
        "output": "components/toolbar/toolbar",
        "entry": "./src/components/customToolbar/app.jsx"
    }
}
```
_scr/components/customToolbar/app.jsx_
(copy and paste from the built in toolbar)
```
// This line is different
import CustomToolbar from "./src/customToolbar";
if (!fin.container || fin.container != "electron") {
  fin.desktop.main(() => {
    let finWindow = fin.desktop.Window.getCurrent();
    finWindow.getOptions((opts) => {
      if (opts.smallWindow) {
        finWindow.setBounds(opts.defaultLeft, opts.defaultTop, opts.defaultWidth, opts.defaultHeight);
      }
    })
  })
}

if (window.FSBL && FSBL.addEventListener) {
    FSBL.addEventListener("onReady", FSBLReady);
} else {
    window.addEventListener("FSBLReady", FSBLReady);
}
function FSBLReady() {
    // This line is different
    CustomToolbar.initialise();
}
```

_scr/components/customToolbar/src/customToolbar.jsx_
```
import Toolbar from "../../../../src-built-in/components/toolbar/src/dynamicToolbar";

import EnvIndicatorComponent from "../../envIndicator/src/components/EnvIndicatorComponent";

class CustomToolbar extends Toolbar {
	constructor(props) {
		super(props);
                // This component will now be available using the menu config
		this.customComponents["EnvIndicatorComponent"] = EnvIndicatorComponent;
	}
}

export default CustomToolbar;
```

This allows for a menu config that looks like:

```
"menus": [
    {
        "align": "left",
        "type": "reactComponent",
        // Using the newly registered component
        "reactComponent": "EnvIndicatorComponent"
    }
]
```