### PR TITLE
15814 remove docking default height

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -75,8 +75,6 @@
 			"groupTileBuffer": 30,
 			"headerHeight": 32,
 			"MINIMUM_WIDTH": 175,
-			"defaultHeight": 39,
-			"defaultWidth": 600,
 			"requireRectangularityForGroupResize": true,
 			"undockDisbandsEntireGroup": false,
 			"fillHolesOnUndock": true,


### PR DESCRIPTION
fix: #id [15814]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15814/details)

**Description of change**
Removes unused properties from docking service configuration.

**Description of testing**
1. Boot the finsemble seed project. Ensure that there are no new errors in the central logger.