### PR TITLE
fix: #id 16247 Spurious Service manager timeout error in console

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -144,7 +144,7 @@
 				process.send({ "action": "timestamp", "milestone": "Application manifest retrieved", "timestamp": Date.now() });
 				notified_config = true;
 				serviceManagerRetrievedTimeout = setTimeout(() => {
-					logToTerminal(errorColor(`ERROR: Finsemble application manifest has been retrieved from the server, but the Finsemble Service Manager has not. This can be caused by a slow internet connection (e.g., downloading assets). This can also be a symptom that you have a hanging openfin process. Please inspect your task manager to ensure that there are no lingering processes. Alternatively, run 'finsemble-cli kill'`))
+					logToTerminal(errorColor(`ERROR: Finsemble application manifest has been retrieved from the server, but the Finsemble System Manager has not. This can be caused by a slow internet connection (e.g., downloading assets). This can also be a symptom that you have a hanging openfin process. Please inspect your task manager to ensure that there are no lingering processes. Alternatively, run 'finsemble-cli kill'`))
 				}, 10000);
 			}
 			next();

--- a/server/server.js
+++ b/server/server.js
@@ -150,7 +150,7 @@
 			next();
 		});
 
-		app.get("/finsemble/components/system/serviceManager/serviceManager.html", (req, res, next) => {
+		app.get("/finsemble/services/systemManager/systemManager.html", (req, res, next) => {
 			if (!notified_sm) {
 				clearTimeout(serviceManagerRetrievedTimeout);
 


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16247/details)

**Description of change**
* Changed the path of the error check to the correct path of the new System Manager

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. The timeout error no longer appears when starting Finsemble
