### PR TITLE
[14743] Print out container name in console

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -376,6 +376,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 			], done);
 		},
 		launchOpenFin: async (done) => {
+			logToTerminal("Using Container: OpenFin", "green");
 			ON_DEATH(() => {
 				killApp("OpenFin", () => {
 					if (watchClose) watchClose();
@@ -405,6 +406,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 			if (done) done();
 		},
 		launchElectron: done => {
+			logToTerminal("Using Container: Electron", "green");
 			const cfg = taskMethods.startupConfig[env.NODE_ENV];
 			const USING_ELECTRON = container === "electron";
 			if (USING_ELECTRON && !FEA_PATH_EXISTS) {


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/14743/details)

**Description of change**
* Added log message containing the container name (Electron/OpenFin)

**Description of testing**
1. Edit `server-environment-startup.json`
1. Set `container` to `Electron` and run `npm run dev`
- [ ] There is `Using Container: Electron` in console logs
1. Set `container` to `OpenFin`  and run `npm run dev`
- [ ] There is `Using Container: OpenFin` in console logs
- [ ] Log line has a green color