### PR TITLE
WIP: [16005] replace `isArrangable` with `isArrangeable`

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -22,7 +22,7 @@
 				"services": {
 					"dockingService": {
 						"canGroup": true,
-						"isArrangable": true
+						"isArrangeable": true
 					}
 				},
 				"components": {
@@ -78,7 +78,7 @@
 			"foreign": {
 				"services": {
 					"workspaceService": {
-						"isArrangable": true
+						"isArrangeable": true
 					}
 				},
 				"components": {
@@ -107,7 +107,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": true
+						"isArrangeable": true
 					}
 				},
 				"components": {
@@ -134,7 +134,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": true
+						"isArrangeable": true
 					}
 				},
 				"components": {
@@ -172,7 +172,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false
+						"isArrangeable": false
 					}
 				},
 				"components": {

--- a/configs/application/presentationComponents.json
+++ b/configs/application/presentationComponents.json
@@ -22,7 +22,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -54,7 +54,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -88,7 +88,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -121,7 +121,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -153,7 +153,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -187,7 +187,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -233,7 +233,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -268,7 +268,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -302,7 +302,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -335,7 +335,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -377,7 +377,7 @@
 				},
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -419,7 +419,7 @@
 				},
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -461,7 +461,7 @@
 				},
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -498,7 +498,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -553,7 +553,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false,
+						"isArrangeable": false,
 						"ignoreSnappingRequests": true,
 						"ignoreTilingAndTabbingRequests": true
 					},
@@ -588,7 +588,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": false
+						"isArrangeable": false
 					}
 				},
 				"components": {
@@ -625,7 +625,7 @@
 				"services": {
 					"dockingService": {
 						"canGroup": false,
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},
@@ -671,7 +671,7 @@
 				"services": {
 					"dockingService": {
 						"canGroup": true,
-						"isArrangable": false
+						"isArrangeable": false
 					}
 				},
 				"components": {
@@ -701,7 +701,7 @@
 			"foreign": {
 				"services": {
 					"dockingService": {
-						"isArrangable": true
+						"isArrangeable": true
 					}
 				},
 				"components": {
@@ -738,7 +738,7 @@
 				"services": {
 					"dockingService": {
 						"canGroup": false,
-						"isArrangable": false,
+						"isArrangeable": false,
 						"shouldRegister": false
 					}
 				},


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/21/cards/16005/details/)

**Description of change**

> The seed configs still reference the deprecated `isArrangable`. Update this to be `isArrangeable`

* Changes

Modified `/configs/application/components.json` and `/configs/application/presentationComponents.json` with `isArrangeable`.

**Description of testing**
1. Open two or more components.
1. Use the "Auto Arrange" button.
1. [ ] The components auto-arranged.
1. Click the auto arrange button again.
1. [ ] Components returned to non-auto-arranged locations