### PR TITLE
feat: #id 16400 simplify deployment

### DIFF
--- a/build/webpack/webpack.components.js
+++ b/build/webpack/webpack.components.js
@@ -146,7 +146,7 @@ function createCopyWebpackConfig() {
 		*/
 		{
 			from: './node_modules/@chartiq/finsemble/dist',
-			to: path.join(__dirname, "../../finsemble/")
+			to: path.join(__dirname, "../../dist/finsemble/")
 		}
 	];
 

--- a/server/server.js
+++ b/server/server.js
@@ -94,15 +94,13 @@
 
 				// Sample server root set to "/" -- must align with paths throughout
 				app.use("/", express.static(rootDir, options));
-				// Open up the Finsemble Components,services, and clients
 
-				app.use("/installers", express.static(path.join(__dirname, "..", "installers"), options));
 				// For Assimilation
 				app.use("/hosted", express.static(path.join(__dirname, "..", "hosted"), options));
 
-				// configs/openfin/manifest-local.json and configs/other/server-environment-startup.json
-				// Make the config public
+				// For installers
 				app.use("/pkg", express.static('./pkg', options));
+
 				cb();
 			}
 		};
@@ -111,7 +109,6 @@
 	// #region Constants
 	const app = express();
 	const rootDir = path.join(__dirname, "..", "dist");
-	const moduleDirectory = path.join(__dirname, "..", "finsemble");
 	const ONE_DAY = 24 * 3600 * 1000;
 	const cacheAge = process.env.NODE_ENV === "development" ? 0 : ONE_DAY;
 	const PORT = process.env.PORT || 3375;

--- a/server/server.js
+++ b/server/server.js
@@ -102,7 +102,6 @@
 
 				// configs/openfin/manifest-local.json and configs/other/server-environment-startup.json
 				// Make the config public
-				app.use("/configs", express.static("./configs", options));
 				app.use("/pkg", express.static('./pkg', options));
 				cb();
 			}

--- a/server/server.js
+++ b/server/server.js
@@ -95,7 +95,7 @@
 				// Sample server root set to "/" -- must align with paths throughout
 				app.use("/", express.static(rootDir, options));
 				// Open up the Finsemble Components,services, and clients
-				app.use("/finsemble", express.static(moduleDirectory, options));
+
 				app.use("/installers", express.static(path.join(__dirname, "..", "installers"), options));
 				// For Assimilation
 				app.use("/hosted", express.static(path.join(__dirname, "..", "hosted"), options));

--- a/server/server.js
+++ b/server/server.js
@@ -95,11 +95,12 @@
 				// Sample server root set to "/" -- must align with paths throughout
 				app.use("/", express.static(rootDir, options));
 
-				// For Assimilation
+				// Optional for Assimilation
 				app.use("/hosted", express.static(path.join(__dirname, "..", "hosted"), options));
 
-				// For installers
-				app.use("/pkg", express.static('./pkg', options));
+				// Optional for installers. This can be removed if/when building installers becomes a part of the 
+				// default build.
+				app.use("/pkg", express.static("./pkg", options));
 
 				cb();
 			}


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16400/details)

**Description of change**
* Copy the _finsemble_ folder to _dist_
* Removed hosting of _finsemble_ and _configs_ from root by server. These folders should be hosted from _dist_
* Removed hosting of _installers_ because it isn't used (installers are in _pkg_)

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. `npm run build`
1. [ ] Observe there is NOT a _finsemble_ folder at the root of seed
1. [x] Observe that there is a _finsemble_ folder in the _dist_ folder.
1. Run finsemble
1. [x] Observet that finsemble starts correctly