### PR TITLE
16401 Change Group to Channel

### DIFF
--- a/src-built-in/components/linker/src/linker.jsx
+++ b/src-built-in/components/linker/src/linker.jsx
@@ -85,7 +85,7 @@ class Linker extends React.Component {
 			if (channel.label) {
 				return <div className="channel-label">{channel.label}</div>
 			} else {
-				return <div className="channel-label">{"Group " + getChannelLabelFromIndex(channel.name, FSBL.Clients.LinkerClient.getAllChannels())}</div>
+				return <div className="channel-label">{"Channel " + getChannelLabelFromIndex(channel.name, FSBL.Clients.LinkerClient.getAllChannels())}</div>
 			}
 		}
 

--- a/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
@@ -121,7 +121,7 @@ export default class LinkerGroups extends React.Component {
          */
         let channels = self.state.channels.map(function (channel, index) {
             let classNames = `linker-group${accessibleLinker ? " linker-group-accessible" : ""} linker-${channel.label}`;
-            return (<div key={channel.name} className={classNames} title={"Group " + getChannelLabelFromIndex(channel.name, FSBL.Clients.LinkerClient.getAllChannels())} style={{ background: channel.color }} onMouseUp={function (e) { self.onClick(e, channel.name) }}>
+            return (<div key={channel.name} className={classNames} title={"Channel " + getChannelLabelFromIndex(channel.name, FSBL.Clients.LinkerClient.getAllChannels())} style={{ background: channel.color }} onMouseUp={function (e) { self.onClick(e, channel.name) }}>
                 {getLabel(channel, accessibleLinker)}
             </div>);
         });


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id [16401]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16401/details)

**Description of change**
* Changed "Group" to "Channel" in the accessible linker.

**Description of testing**

1. Open the Linker
1. See that it reads "Channel 1" and not "Group 1".
1. Assign a color channel.
1. Hover over the color on the titlebar and see that the tooltip reads "Channel 1"