### PR TITLE
[16424] read and print out OpenFin/Electron version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -148,13 +148,13 @@ const { launch, connect } = require('hadouken-js-adapter');
 					'node_modules',
 					'electron',
 					'package.json')
-			)
-			return packageFile.version
+			);
+			return packageFile.version;
 		} catch (error) {
 			logToTerminal(`Failed to get electron's verion from FEA: ${error.message}`, "red");
-			return 'unknown'
+			return 'unknown';
 		}
-	}
+	};
 	// #endregion
 
 	// #region Task Methods

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -118,6 +118,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 		return rc;
 	}
 
+	
 	// Currently supported desktop agents include "openfin" and "electron". This can be set either
 	// with the environment variable container or by command line argument `npx gulp dev --container:electron`
 	let container = envOrArg("container", "openfin");
@@ -130,6 +131,30 @@ const { launch, connect } = require('hadouken-js-adapter');
 	// This will get set when the container (Electron or Openfin) is launched. This is used to calculate how long it takes to start up the app.
 	let launchTimestamp = 0;
 
+	/**
+	 * Mody 10/04/2019
+	 * Reads installed Electron's version from FEA repo.
+	 * Another option is to export electron's version in
+	 * deploymentHelpers in FEA. However I'm just avoiding 2 PRs
+	 */
+	const getElectronVersion = () => {
+		// You may run `npm run dev` before running `npm i` inside 
+		// finsemble-electron-adapter in that case, the electron
+		// module does not exists.
+		try {
+			const packageFile = require(
+				path.join(
+					FEA_PATH,
+					'node_modules',
+					'electron',
+					'package.json')
+			)
+			return packageFile.version
+		} catch (error) {
+			logToTerminal(`Failed to get electron's verion from FEA: ${error.message}`, "red");
+			return 'unknown'
+		}
+	}
 	// #endregion
 
 	// #region Task Methods
@@ -376,6 +401,8 @@ const { launch, connect } = require('hadouken-js-adapter');
 			], done);
 		},
 		launchOpenFin: async (done) => {
+			// We are unable to read OpenFin version at the moment.
+			// We request it after hadouken connection.
 			logToTerminal("Using Container: OpenFin", "green");
 			ON_DEATH(() => {
 				killApp("OpenFin", () => {
@@ -395,6 +422,8 @@ const { launch, connect } = require('hadouken-js-adapter');
 					// We want OpenFin to exit as our application exists.
 					nonPersistent: true
 				});
+				const openfinVersion = await fin.System.getVersion();
+				logToTerminal(`Openfin version: ${openfinVersion}`, "green");
 				if (watchClose) watchClose();
 				// Once OpenFin exits we shut down the server.
 				fin.once('disconnected', process.exit);
@@ -406,7 +435,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 			if (done) done();
 		},
 		launchElectron: done => {
-			logToTerminal("Using Container: Electron", "green");
+			logToTerminal(`Using Container: Electron@${getElectronVersion()}`, "green");
 			const cfg = taskMethods.startupConfig[env.NODE_ENV];
 			const USING_ELECTRON = container === "electron";
 			if (USING_ELECTRON && !FEA_PATH_EXISTS) {


### PR DESCRIPTION
feat: #id [16424 ]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16424/details)

**Description of change**
* Read Electron version from package.json
* Read OpenFin version with hadouken
* Print out container version next to its name

**Description of testing**
1. Checkout this branch
1. Set container to (electron/openfin) and run `npm run dev`

Look for container name and version in logs printed out in green color.
