### PR TITLE
[11790] Native component freeze/breaks when tabbing on self

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
+++ b/src-built-in/components/floatingTitlebar/src/components/TabRegion.jsx
@@ -1,9 +1,7 @@
 
 
 import React from "react";
-import ReactDOM from "react-dom";
 import Tab from "./tab";
-import { FinsembleDnDContext, FinsembleDroppable } from '@chartiq/finsemble-react-controls';
 import { FinsembleHoverDetector } from "@chartiq/finsemble-react-controls";
 import Logo from "./logo";
 import Title from "../../../common/windowTitle"
@@ -173,10 +171,18 @@ export default class TabRegion extends React.Component {
     drop(e) {
         e.preventDefault();
         e.stopPropagation();
-
         FSBL.Clients.Logger.system.debug("Tab drag drop.");
-        let identifier = this.extractWindowIdentifier(e);
-        if (!identifier) return; // the dropped item is not a tab
+        const identifier = this.extractWindowIdentifier(e);
+        // the dropped item is not a tab
+        if (!identifier) return; 
+        // If we only have single tab and its the activeTab
+        // and if the dropped window's name is the same as 
+        // active tab's windowName we cancel tabbing.
+        if (
+            this.state.tabs.length === 1
+            && identifier.windowName === this.state.activeTab.windowName) {
+            return this.cancelTabbing();
+        }
         FSBL.Clients.WindowClient.stopTilingOrTabbing({ allowDropOnSelf: true, action: "tabbing" }, () => {
             FSBL.Clients.RouterClient.transmit("tabbingDragEnd", { success: true });
             if (identifier && identifier.windowName) {


### PR DESCRIPTION
fix: #id [11790]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/11790/details)

**Description of change**
* Add check and cancel tabbing when necessary

**Description of testing**
This issue is happening when there is a single tab only. When you drag the component title and drop it on itself the component will freeze, you won't be able to move it around anymore and you won't be able to resize it. See gif below

![working-selftab-freeze](https://user-images.githubusercontent.com/1192143/66648683-d3f4c880-ec34-11e9-8106-a3dba5c0c526.gif)

To test the fix
1. Please checkout planned/3.13.0 and experience the bug
1. Check out this branch and run finsemble `npm run dev`
1. Launch a Notepad
1. Expand floating titlebar and drag the title and drop it on itself
1. Collapse floating titlebar and Try moving notepad/resizing it

- [ ] Notepad can still be tabbed with other components
- [ ] Notepad can be moved around
- [ ] Notepad can be resized

![working-selftab11](https://user-images.githubusercontent.com/1192143/66648865-52ea0100-ec35-11e9-8c58-70a33ca50e6a.gif)
