### PR TITLE
Bind context for blur listener in react lifecycle events

### DIFF
--- a/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
@@ -31,17 +31,16 @@ export default class AppActionsMenu extends React.Component {
 		this.onRemove = this.onRemove.bind(this);
 		this.setMenuRef = this.setMenuRef.bind(this);
 		this.deleteApp = this.deleteApp.bind(this);
-		this.handleClickOutside = this.handleClickOutside.bind(this);
 	}
 
 	componentDidMount() {
-		document.addEventListener("mousedown", this.handleClickOutside);
-		finsembleWindow.addEventListener("blurred", this.handleClickOutside);
+		document.addEventListener("mousedown", this.handleClickOutside.bind(this));
+		finsembleWindow.addEventListener("blurred", this.handleClickOutside.bind(this));
 	}
 
 	componentWillUnmount() {
-		document.removeEventListener("mousedown", this.handleClickOutside);
-		finsembleWindow.removeEventListener("blurred", this.handleClickOutside);
+		document.removeEventListener("mousedown", this.handleClickOutside.bind(this));
+		finsembleWindow.removeEventListener("blurred", this.handleClickOutside.bind(this));
 	}
 
 	toggleMenu(e) {


### PR DESCRIPTION
fix: #16691 [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16691/details)

**Description of change**
* Bind `this` context for the finsembleWindow listeners inside the listener attachment/removal. Something about the timing of the react lifecycle events and when the listener is being referenced in Finsemble would cause finsemble to lose the handler.

**Description of testing**
1. Change the app launcher to use the my apps menu in Finsemble
1. Open Central Logger
1. Switch between 'My Apps' and 'Favorites' on the left-pane and make sure no errors appear in the CL.
1. Use the search function to search for something that will return results (e.g. "proc")
1. [ ] The central logger does not show any errors regarding 'handler of undefined'