### PR TITLE
fix: #id 16706 update my apps folders to match the components config setting

### DIFF
--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -84,7 +84,6 @@ function initialize(callback = Function.prototype) {
 				loadInstalledComponentsFromStore(() => {
 					//We load our stored components(config driven) here
 					loadInstalledConfigComponents(callback);
-					console.log(`after loading installed config component, apps:${JSON.stringify(data.apps)}`)
 				});
 
 			});
@@ -174,12 +173,18 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 	FSBL.Clients.LauncherClient.getComponentList((err, componentList) => {
 		let componentNameList = Object.keys(componentList);
 		
-		// Update the folders under the "App" menu and delete any apps in the folder that are no longer in the config
-		const folders = data.folders;
+		/*
+		 * Update the folders under the "App" menu and delete any apps in the folder 
+		 * that are no longer in the config and are not user defined components.
+		 */
+		const { folders } = data;
+		// Get the user defined apps
+		const apps = Object.keys(data.apps);
 		Object.keys(folders).forEach(folderName => {
 			const appsName = Object.keys(folders[folderName]["apps"]);
 			appsName.forEach(appName => {
-				if (!componentNameList.includes(appName)) {
+				// If the component is not in the config component list and is not a user defined component
+				if (!componentNameList.includes(appName) && !apps.includes(folders[folderName]["apps"][appName]["appID"].toString())) {
 					// Delete app from the folder
 					delete data.folders[folderName]["apps"][appName];
 				}

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -186,7 +186,7 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 				// If the component is not in the config component list and is not a user defined component
 				if (!componentNameList.includes(appName) && !apps.includes(folders[folderName]["apps"][appName]["appID"].toString())) {
 					// Delete app from the folder
-					delete data.folders[folderName]["apps"][appName];
+					delete folders[folderName]["apps"][appName];
 				}
 			})
 		});

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -84,6 +84,7 @@ function initialize(callback = Function.prototype) {
 				loadInstalledComponentsFromStore(() => {
 					//We load our stored components(config driven) here
 					loadInstalledConfigComponents(callback);
+					console.log(`after loading installed config component, apps:${JSON.stringify(data.apps)}`)
 				});
 
 			});
@@ -172,6 +173,19 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 	// Get the list of components from the launcher service
 	FSBL.Clients.LauncherClient.getComponentList((err, componentList) => {
 		let componentNameList = Object.keys(componentList);
+		
+		// Update the folders under the "App" menu and delete any apps in the folder that are no longer in the config
+		const folders = data.folders;
+		Object.keys(folders).forEach(folderName => {
+			const appsName = Object.keys(folders[folderName]["apps"]);
+			appsName.forEach(appName => {
+				if (!componentNameList.includes(appName)) {
+					// Delete app from the folder
+					delete data.folders[folderName]["apps"][appName];
+				}
+			})
+		});
+		
 		componentNameList.map(componentName => {
 			// If the app is already in our list move on
 			if (appInAppList(componentName)) return;


### PR DESCRIPTION
fix: #id 16706

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16706/details/)

**Description of change**
* After the apps are loaded from the config, delete the apps inside the "App" menu folders so that the apps in the folders match the component config

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Test this branch along with Finsemble core and FEA on planned/3.13.0 branch
1. Update finsemble-seed -> src-built-in -> components -> toolbar -> config.json to use the "My app" menu instead of "App Launcher" menu
1. Launch finsemble, create 1 or 2 new folders, add several components (i.e. welcome component and notepad) to the "favorite" folder and the new folders you created.
1. Go to finsemble -seed -> configs -> application -> components.json, delete the component config (i.e. welcome component and notepad)
1. Rebuild and restart finsemble
1. [x] The deleted components (i.e. welcome component and notepad) are no longer in the "apps" folders