### PR TITLE
fix: floating titlebar maximize error

### DIFF
--- a/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
+++ b/src-built-in/components/floatingTitlebar/src/stores/headerStore.js
@@ -116,7 +116,6 @@ var Actions = {
 			wrappedWindow.addListener("closed", Actions.onCompanionClosed);
 			wrappedWindow.addListener("hidden", Actions.onCompanionHidden);
 			wrappedWindow.addListener("shown", Actions.onCompanionShown);
-			wrappedWindow.addListener("maximized", Actions.onCompanionMaximized);
 			wrappedWindow.addListener("restored", Actions.onCompanionRestored);
 			wrappedWindow.addListener("bringToFront", Actions.onCompanionBringToFront);
 			wrappedWindow.addListener("minimized", Actions.onCompanionMinimized);


### PR DESCRIPTION
When the event handler was removed in 45771b5498bf861e7388191499102faed73b83ce the binding of it was not removed.

This removes the binding, so an undefined handler is no longer bound.

fix: #16759

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16759/details)

**Description of testing**

Maximize a native window on OpenFin that has a floating titlebar (like Notepad.) Observe no errors in the Central Logger from that action.