### PR TITLE
fix: #id 17780 App URL Validation

### DIFF
--- a/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
+++ b/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
@@ -147,7 +147,7 @@ export default class AddNewAppForm extends React.Component {
 	 * @param {keyboardEvent} e
 	 */
 	validateURL(url) {
-		return /^(?:\w+?:\/\/)+[\w-]{1,64}+(?:[\w-]{1,64}+)?(?:\.[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]{1,64})?(?:\:\d+)?$/gmi.test(url);
+		return /^(?:\w+?:\/\/)+[\w-]{1,64}(?:[\w-]{1,64})?(?:\.[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]{1,64})?(?:\:\d+)?$/gmi.test(url);
 	}
 
 	/**

--- a/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
+++ b/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
@@ -144,10 +144,14 @@ export default class AddNewAppForm extends React.Component {
 	 * Matches valid URLs. Must include a protocol.
 	 * Does _not_ enforce TLD to accomodate port-based URLs
 	 * Enforces max length of 64 characters per piece as per spec
+	 * 
+	 * Examples of passing: http://www.google.com http://localhost:3000 fsbl://localhost
+	 * Example of not passing: localhost
+	 * 
 	 * @param {keyboardEvent} e
 	 */
 	validateURL(url) {
-		return /^(?:\w+?:\/\/)+[\w-]{1,64}(?:[\w-]{1,64})?(?:\.[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]{1,64})?(?:\:\d+)?$/gmi.test(url);
+		return /^(?:\w+?:\/\/)+[\w-]{1,64}(?:[\w-]{1,64})?(?:\.[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]{1,64})?(?:\:\d+)?$/gi.test(url);
 	}
 
 	/**

--- a/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
+++ b/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
@@ -141,11 +141,13 @@ export default class AddNewAppForm extends React.Component {
 		});
 	}
 	/**
-	 * WILD regex I stole off of google. Allows http or https. Requires some kind of .co or something. Great.
+	 * Matches valid URLs. Must include a protocol.
+	 * Does _not_ enforce TLD to accomodate port-based URLs
+	 * Enforces max length of 64 characters per piece as per spec
 	 * @param {keyboardEvent} e
 	 */
 	validateURL(url) {
-		return /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm.test(url);
+		return /^(?:\w+?:\/\/)+[\w-]{1,64}+(?:[\w-]{1,64}+)?(?:\.[\w\-\._~:\/?#[\]@!\$&'\(\)\*\+,;=.]{1,64})?(?:\:\d+)?$/gmi.test(url);
 	}
 
 	/**


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/17780/details/)

**Description of change**
* Relaxes rules in order to allow:
    1. Custom protocols (_e.g._ `finsemble://`)
    1. Allows for port-based URLs (_e.g._ `http://localhost:3000`)

 * Revised comment

**Description of testing**

1. Enable My Apps: edit `/src-built-in/components/Toolbar/config.json` as such:
    
```js
    {
        "align": "left",
        "label": "Apps",
        "id": "app-launcher",
        "comment": "Change menuType to 'My Apps' for a preview of the finsemble app catalog!",
        "menuType": "My Apps"
    },
```
1. You may also need to add a 'foreign' element to the config of nonConfiguredComponent (as this being missing breaks My Apps...)
1. Open Apps menu item
1. Hit 'Add new app' in the bottom left
1. Enter the URL `http://localhost:3000` and submit the form
    1. [ ] `http://localhost:3000` is allowed.
    1. [ ] `fsbl://localhost` is allowed
    1. [ ] `localhost` is not allowed.

Regex test suite: https://regex101.com/r/Z85kF8/13/tests