### PR TITLE
feat: #id 16931 implement DOM-based movement for the toolbar

### DIFF
--- a/assets/css/_toolbar.css
+++ b/assets/css/_toolbar.css
@@ -235,13 +235,12 @@ img.pinned-icon {
 .finsemble-toolbar-drag-handle > svg {
     width: 23px;
     margin-top: -7px;
-  }
+}
 
-  .finsemble-toolbar-drag-handle {
+.finsemble-toolbar-drag-handle {
     margin-left: 3px;
     padding-left: 2px;
     padding-right: 0px;
     padding-top: 15px;
-    -webkit-app-region: drag;
     cursor: grab;
-  }
+}

--- a/assets/css/_windowTitleBar.css
+++ b/assets/css/_windowTitleBar.css
@@ -1,7 +1,6 @@
 @import url('./_themeWhitelabel.css');
 
 .fsbl-drag-handle {
-    /* -webkit-app-region: drag; */
     z-index: 2147483641;
     /* use below with window scrollbar hack */
     position: fixed;

--- a/src-built-in/components/toolbar/components/DragHandle.jsx
+++ b/src-built-in/components/toolbar/components/DragHandle.jsx
@@ -4,10 +4,16 @@ import { ReactComponent as DragHandleIcon } from '../../../../assets/img/toolbar
 
 const DragHandle = () => {
 	const currentWindow = fin.desktop.Window.getCurrent();
+	const handleMouseDown = (event) => {
+		currentWindow.onMouseDown(event);
+	};
+	const handleMouseUp = (event) => {
+		currentWindow.onMouseUp(event);
+	};
 	return (
 		<span className="cq-drag finsemble-toolbar-drag-handle"
-			onMouseDown={e => currentWindow.onMouseDown(e)}
-			onMouseUp={e => currentWindow.onMouseUp(e)}
+			onMouseDown={handleMouseDown}
+			onMouseUp={handleMouseUp}
 		>
 			<DragHandleIcon />
 		</span>


### PR DESCRIPTION
feat: #id 16931

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16931/details/)

**Description of change**
* implement DOM-based movement for the toolbar
* take out the -webkit-app-region code

**Description of testing**
1. Pull down this branch, test along with branch `osx_movement_4.0.0` for seed and FEA (Note: if you are on a planned/3.x.x release before you need to run `npm i` before you build)
1. [x] Launch finsemble. Make sure the toolbar can dock on different monitors and claim space.