### PR TITLE
4.0 Startup-Config Tweak (no affect on runtime)

### DIFF
--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -77,7 +77,7 @@
 			"defaults": {
 				"startServiceTimeout": 10000,
 				"startComponentTimeout": 15000,
-				"startModuleTimeout": 10000
+				"startTaskTimeout": 10000
 			}
 		},
         "importConfig": [


### PR DESCRIPTION
Small Tweak -- This is a PR without a ticket.  Kyle found old name was used while creating new startup test cases.  

**Description of change**
* In the 4.0 seed I updated the config example to use new name (i.e. task instead of module).  

