### PR TITLE
feat: #id 16932 to 16935 onmousedown onmouseup event handler naming change

### DIFF
--- a/src-built-in/components/toolbar/components/DragHandle.jsx
+++ b/src-built-in/components/toolbar/components/DragHandle.jsx
@@ -5,10 +5,10 @@ import { ReactComponent as DragHandleIcon } from '../../../../assets/img/toolbar
 const DragHandle = () => {
 	const currentWindow = fin.desktop.Window.getCurrent();
 	const handleMouseDown = (event) => {
-		currentWindow.onMouseDown(event);
+		currentWindow.startMovingWindow(event);
 	};
 	const handleMouseUp = (event) => {
-		currentWindow.onMouseUp(event);
+		currentWindow.stopMovingWindow(event);
 	};
 	return (
 		<span className="cq-drag finsemble-toolbar-drag-handle"

--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -205,8 +205,8 @@ class WindowTitleBar extends React.Component {
 			const currentWindow = fin.desktop.Window.getCurrent();
 			dragHandle = document.createElement("div");
 			dragHandle.className = "fsbl-drag-handle";
-			dragHandle.onmousedown = (e) => {currentWindow.onMouseDown(e)}
-			dragHandle.onmouseup = (e) => {currentWindow.onMouseUp(e)}
+			dragHandle.onmousedown = (e) => {currentWindow.startMovingWindow(e)}
+			dragHandle.onmouseup = (e) => {currentWindow.stopMovingWindow(e)}
 
 			fsblHeader.insertBefore(dragHandle, fsblHeader.firstChild);
 			var self = this;


### PR DESCRIPTION
feat: #id 16932 to 16935
**Note**: 4 cards' work is combined into 1 PR because we couldn't test the code effectively if it's broken down one by one.

[Kanban link 1](https://chartiq.kanbanize.com/ctrl_board/18/cards/16932/details/)
[Kanban link 2](https://chartiq.kanbanize.com/ctrl_board/18/cards/16933/details/)
[Kanban link 3](https://chartiq.kanbanize.com/ctrl_board/18/cards/16934/details/)
[Kanban link 4](https://chartiq.kanbanize.com/ctrl_board/18/cards/16935/details/)

**Description of change**
* Change onmousedown and onmouseup event handler names

**Description of testing**
Testing details described in https://github.com/ChartIQ/finsemble-electron-adapter/pull/162