### PR TITLE
feat: #id 17132 validate max node version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,7 +60,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 		let tempVersionArray;
 		let semverObject;
 		if (typeof version !== 'string') {
-			console.log(`Version must be type string`);
+			console.log(`Version must be type string but is ${typeof version}`);
 			return;
 		}
 		// Split the version into a temp array.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -70,19 +70,20 @@ const { launch, connect } = require('hadouken-js-adapter');
 		} else {
 			tempVersionArray = version.split('.')
 		}
-		if (tempVersionArray)
+		if (tempVersionArray.length === 3) {
 
-		// Convert each array element to a number and store in the object.
-		semverObject = {
-			majorVersion: Number(tempVersionArray[0]) || null,
-			minorVersion: Number(tempVersionArray[1]) || null,
-			patchVersion: Number(tempVersionArray[2]) || null,
+			// Convert each array element to a number and store in the object.
+			semverObject = {
+				majorVersion: Number(tempVersionArray[0]) || null,
+				minorVersion: Number(tempVersionArray[1]) || null,
+				patchVersion: Number(tempVersionArray[2]) || null,
+			}
+			// If major, minor or patch versions are missing or not a number return nothing
+			if (!semverObject.majorVersion || !semverObject.minorVersion || !semverObject.patchVersion) {
+				return;
+			}
+			return semverObject
 		}
-		// If major, minor or patch versions are missing or not a number return nothing
-		if (!semverObject.majorVersion || !semverObject.minorVersion || !semverObject.patchVersion) {
-			return;
-		}
-		return semverObject
 	}
 
 	/** 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 	const createSemverObject = (version) => {
 		let tempVersionArray;
 		let semverObject;
-		if (!version || typeof version !== 'string') {
+		if (typeof version !== 'string') {
 			console.log(`Version must be type string`);
 			return;
 		}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -54,7 +54,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 
 	/** 
 	* Validates the current node version against supported node versions specified in this file
-	* Returns true of false if current node version is valid
+	* Returns boolean indicating whether current node version is valid
 	* Currently only validates against a max node version
 	*
 	* Note: This method is being used instead of npm engines because of an npm bug where warnings don't print


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/17132/details)

**Description of change**
* Added validation for max node version being 10.15.3 (can be changed in the gulpfile). If validation fails an error will be logged but finsemble will still start.
* Did not use npm engines because it has a bug where the version warning doesn't log prior to npm version 6.12.0

**Description of testing**
Markdown will convert the 1s to the appropriate number.
To test without changing npm versions:
1. Note your node version, if <= 10.15.3, start finsemble and verify there are no errors in the terminal above the launching Finsemble line.
2. In the finsemble-seed gulpfile.js change MAX_NODE_VERSION to a version below your current node version
3. Launch finsemble, verify finsemble launches but there is an error in the terminal about the node version not supported

If you'd prefer you can update node to be above the supported version, though updating node is not trivial. Note that due to a bug in node 10.16 and up finsemble may or may not start, but the error should still be logged about the node version not being supported
To update Node using nvm:
1. run 'nvm install 10.16.0'
1. Make sure no finsemble build processes are running (fea, finsemble etc). In the finsemble repo, navigate to node_modules and delete the node-sass folder
1. in %APPDATA%/npm-cache delete the node-sass folder
1. npm install in the finsemble directory (make sure node-sass reinstalls, if not npm install node-sass)
1. in the fea and finsemble folders run 'npm link' (you need to set up symlinks from these folders to the new version folder in the nvm directory, seed's symlinks are connected to this folder).
1. In the finsemble-seed directory run npm link @chartiq/finsemble (and @ chartiq/finsemble-electron-adapter) to transfer seeds links to the links in your 10.16.0 nvm directory from your old node directory ( Actually this step is probably not necessary because seed seems to just link to the symlinked nvm version in Program Files, but it doesn't hurt to run)
1. Build finsemble and fea then launch finsemble. There should be an error about node 10.16.0 not being supported
1. After testing use the above steps to go back to a version of node at or before 10.15.3 (do not stay on node 10.16.0)