### PR TITLE
fix: app url validation

### DIFF
--- a/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
+++ b/src-built-in/components/myApps/src/components/AddNewAppForm.jsx
@@ -141,11 +141,19 @@ export default class AddNewAppForm extends React.Component {
 		});
 	}
 	/**
-	 * WILD regex I stole off of google. Allows http or https. Requires some kind of .co or something. Great.
-	 * @param {keyboardEvent} e
+	 * Attempt to make a URL object, if successful the provided URL is valid.
+	 * If the URL constructor determines the provided string to be invalid it throws a TypeError.
+	 *
+	 * @param {string} url
+	 * @return boolean
 	 */
 	validateURL(url) {
-		return /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm.test(url);
+		try {
+			new URL(url);
+			return true;
+		} catch(e) {
+			return false;
+		}
 	}
 
 	/**


### PR DESCRIPTION
URLs were being validated with a buggy regex expression for valid URLs.
This changes the validation to use the URL constructor for simplicity and robustness.

fix: #id [18357](https://chartiq.kanbanize.com/ctrl_board/18/cards/18357/details/)

## Tests

Followed test instructions in card's referenced test case failure.