### PR TITLE
fix: #id 18161 spawn quick components with the correct config

### DIFF
--- a/src-built-in/components/myApps/src/components/AppDefinition.jsx
+++ b/src-built-in/components/myApps/src/components/AppDefinition.jsx
@@ -37,17 +37,7 @@ export default class AppDefinition extends React.Component {
 		setTimeout(() => {
 			finsembleWindow.hide();
 		}, 100);
-		const name = this.props.app.title || this.props.app.name
-		// If the app has a URL property
-		// For now, this means it was manually added
-		// So lets spawn from URL
-		if (this.props.app.url) {
-			return FSBL.Clients.LauncherClient.spawn(null, {
-				url: this.props.app.url,
-				addToWorkspace: true
-			})
-		}
-		// Otherwise launch application by name
+		const name = this.props.app.title || this.props.app.name;
 		FSBL.Clients.LauncherClient.spawn(name, {
 			addToWorkspace: true
 		});


### PR DESCRIPTION
fix: #id 18161

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18161/details/)

**Description of change**
* Always spawn components with a componentType. The original bug happens because we're spawning quick components without setting componentType, which is causing launcher.js to spawn it as an unknownComponent

**Description of testing**
1. Build and start finsemble
1. Create a quick component
1. Save the quick component in the workspace
1. [x] Reload the workspace and make sure the quick components comes up with the correct webcontent (instead of as an unknownComponent)
1. [x] Restart finsemble and make sure the quick components comes up with the correct webcontent (instead of as an unknownComponent)
1. [x] Other components are also spawned correctly