### PR TITLE
fix #id: 18316 Remove OpenFin specific bounds hack

### DIFF
--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -6,21 +6,3 @@
 // Static vs Dynamic Toolbar
 import Toolbar from "./dynamicToolbar";
 // import Toolbar from "./staticToolbar";
-
-function FSBLReady() {
-  //Band-aid. Openfin not respecting small bounds on startup.
-  if (!FSBL.System.container || FSBL.System.container != "electron") {
-    let finWindow = FSBL.System.Window.getCurrent();
-    finWindow.getOptions((opts) => {
-      if (opts.smallWindow) {
-        finWindow.setBounds(opts.defaultLeft, opts.defaultTop, opts.defaultWidth, opts.defaultHeight);
-      }
-    })
-  }
-}
-
-if (window.FSBL && FSBL.addEventListener) {
-  FSBL.addEventListener("onReady", FSBLReady);
-} else {
-  window.addEventListener("FSBLReady", FSBLReady);
-}


### PR DESCRIPTION
fix: #id [18316]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18316/details)

**Description of change**
* Remove OF specific hack to reset finWindow bounds on window ready.

**Description of testing**
1. Undock toolbar from primary monitor and move to another monitor docked or undocked
1. Restart ~10 times and ensure the toolbar restarts in the same location it was left
1. [ ] Toolbar returned to saved location