### PR TITLE
fix: #id 16324 manifest router config

### DIFF
--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -83,8 +83,8 @@
         "importConfig": [
             "$applicationRoot/configs/application/config.json"
         ],
-        "IAC": {
-            "serverAddress": "ws://127.0.0.1:3376"
+        "router" :{
+            "crossDomainTransport": "IPCBus"
         }
     }
 }

--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -83,7 +83,7 @@
         "importConfig": [
             "$applicationRoot/configs/application/config.json"
         ],
-        "router" :{
+        "router": {
             "crossDomainTransport": "IPCBus"
         }
     }


### PR DESCRIPTION
fix: #id 16324

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16324/details/)

**Description of change**
* Configure the router transport through "router" instead of "IAC" according to the documentation to avoid confusion

**Description of testing**
Detailed description is described in https://github.com/ChartIQ/finsemble/pull/1588