### PR TITLE
18061 Reset arranged status on toolbar move

### DIFF
--- a/src-built-in/components/toolbar/components/AutoArrange.jsx
+++ b/src-built-in/components/toolbar/components/AutoArrange.jsx
@@ -8,20 +8,34 @@ export default class AutoArrange extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			isAutoArranged: false
+			isAutoArranged: false,
+			autoArrangeData: {}
 		};
 		this.bindCorrectContext();
 		let self = this;
-		FSBL.Clients.LauncherClient.getMonitorInfo({
-			windowIdentifier: FSBL.Clients.LauncherClient.windowIdentifier
-		}, (err, monitorInfo) => {
-			FSBL.Clients.RouterClient.subscribe('DockingService.AutoarrangeStatus', function (err, response) {
+		/*
+			11/6/19 JC: If the auto arrange status changes this could be due to the toolbar changing monitors.
+			The old way only pulled monitor info once and compared against the updating auto arrange status.
+			This way, every time the auto arrange status changes get the updated monitor info 
+			from docking and compare against updated monitor info
+		*/
+		FSBL.Clients.RouterClient.subscribe('DockingService.AutoarrangeStatus', function(err, response) {
+			FSBL.Clients.WindowClient.getMonitorInfo({}, (err, monitorInfo) => {
 				self.setState({
+					autoArrangeData: response.data.isAutoArranged,
 					isAutoArranged: response.data.isAutoArranged && response.data.isAutoArranged[monitorInfo.name]
 				});
 			});
-		})
+		});
 
+		//If the toolbar is moved, recalculate the auto arrange status since the monitor might have changed
+		finsembleWindow.addEventListener('bounds-change-end', () => {
+			FSBL.Clients.WindowClient.getMonitorInfo({}, (err, monitorInfo) => {
+				self.setState({
+					isAutoArranged: this.state.autoArrangeData && this.state.autoArrangeData[monitorInfo.name]
+				});
+			});
+		});
 	}
 
 	bindCorrectContext(){
@@ -29,9 +43,6 @@ export default class AutoArrange extends React.Component {
 	}
 
 	autoArrange() {
-		this.setState({
-			isAutoArranged: !this.state.isAutoArranged
-		});
 		FSBL.Clients.WorkspaceClient.autoArrange({}, () => {
 			ToolbarStore.bringToolbarToFront();
 		});


### PR DESCRIPTION
fix: #id [18061]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18061/details)

**Description of change**
* Adds logic to properly manage toolbar's representation of auto arrange

Check this out in tandem with core branch: https://github.com/ChartIQ/finsemble/pull/1594

**Description of testing**
1. https://chartiq.spiraservice.net/3/TestCase/58.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1113.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1114.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1115.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1116.aspx
1. https://chartiq.spiraservice.net/3/TestCase/61.aspx
1. https://chartiq.spiraservice.net/3/TestCase/60.aspx
1. https://chartiq.spiraservice.net/3/TestCase/49.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1449.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1448.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1174.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1206.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1503.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1504.aspx
1. https://chartiq.spiraservice.net/3/TestCase/82.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1227.aspx
1. https://chartiq.spiraservice.net/3/TestCase/1315.aspx