### PR TITLE
18656 handle greedy key prefixes in clear cache and improve keys implementation

### DIFF
--- a/src-built-in/adapters/indexedDBAdapter.js
+++ b/src-built-in/adapters/indexedDBAdapter.js
@@ -132,7 +132,7 @@ const IndexedDBAdapter = function (uuid) {
 	// #endregion
 
 	/**
-	 * Get the prefix used to filter keys for particular topics and key prefixes.
+	 * Get the prefix used to filter keys with an option topic and key prefixe.
 	 *
 	 * @param {object} params
 	 * @param {string} params.topic The topic
@@ -140,8 +140,11 @@ const IndexedDBAdapter = function (uuid) {
 	 * @private
 	 */
 	this.getKeyPreface = (params) => {
-		const keyPrefix = "keyPrefix" in params ? params.keyPrefix : "";
-		const preface = `${this.getUserPreface()}:${params.topic}:${keyPrefix}`;
+		let preface = this.getUserPreface();
+		if (params && params.topic){
+			const keyPrefix = "keyPrefix" in params ? params.keyPrefix : "";
+			preface += `${params.topic}:${keyPrefix}`;
+		}
 
 		return preface;
 	}
@@ -151,7 +154,7 @@ const IndexedDBAdapter = function (uuid) {
 	 * @private
 	 */
 	this.getUserPreface = () => {
-		const preface = `${this.baseName}:${this.userName}`;
+		const preface = `${this.baseName}:${this.userName}:`;
 		return preface;
 	}
 
@@ -171,8 +174,8 @@ const IndexedDBAdapter = function (uuid) {
 	}
 	// #region Interface Methods
 	/**
-	 * This method should be used very, very judiciously. It's essentially a method designed to wipe the database for a
-	 * particular user.
+	 * This method should be used very, very judiciously. It's essentially a method designed to wipe the 
+	 * database for a particular user.
 	 */
 	this.clearCache = (params, cb) => {
 		if (!initialized) {
@@ -320,7 +323,7 @@ const IndexedDBAdapter = function (uuid) {
 	}
 
 	/**
-	 * Returns all keys stored in IndexDB.
+	 * Returns all keys stored in IndexDB, with an option topic and keyPrefix.
 	 *
 	 * @param {object} params
 	 * @param {function} cb

--- a/src-built-in/adapters/indexedDBAdapter.js
+++ b/src-built-in/adapters/indexedDBAdapter.js
@@ -132,10 +132,10 @@ const IndexedDBAdapter = function (uuid) {
 	// #endregion
 
 	/**
-	 * Get the prefix used to filter keys with an option topic and key prefixe.
-	 *
+	 * Get the prefix used to filter keys with an optional topic and keyPrefix.
+	 * Note that if topic is not provided, keyPrefix is also ignored.
 	 * @param {object} params
-	 * @param {string} params.topic The topic
+	 * @param {string} params.topic The topic (optional).
 	 * @param {string} params.keyPrefix The key prefix (optional).
 	 * @private
 	 */

--- a/src-built-in/adapters/localStorageAdapter.js
+++ b/src-built-in/adapters/localStorageAdapter.js
@@ -67,20 +67,24 @@ const LocalStorageAdapter = function (uuid) {
 
 	// Return prefix used to filter keys.
 	this.getKeyPreface = function (self, params) {
-		let preface = self.baseName + ":" + self.userName + ":" + params.topic + ":";
-		if ("keyPrefix" in params) {
-			preface = preface + params.keyPrefix;
+		let preface = self.baseName + ":" + self.userName + ":"
+		if (params && params.topic){
+			preface += params.topic + ":";
+			if (params.keyPrefix) {
+				preface += params.keyPrefix;
+			}
 		}
+		
 		return preface;
 	};
 
 	/**
-	 * Returns all keys stored in localstorage of a given topic and keyPrefix.
+	 * Returns all keys stored in localstorage for the current user, with an optional topic and keyPrefix.
 	 *
 	 * LocalStorage is synchronous, so the callback is optional (the function
 	 * immediately returns the results if the callback is omitted).
 	 *
-	 * @param {*} params An object that must include the topic and keyPrefix of the desired keys.
+	 * @param {*} params An object that may include the topic and keyPrefix of the desired keys.
 	 * @param {*} cb An optional callback that will be passed any errors that occurred and the found keys.
 	 */
 	this.keys = function (params, cb) {
@@ -168,7 +172,7 @@ const LocalStorageAdapter = function (uuid) {
 			// Iterate over localStorage and insert data related to the user into an array.
 			for (let i = 0; i < localStorage.length; i++) {
 				//console.log("localStorage.key(i):::", localStorage.key(i).substring(0, (this.baseName + ":" + this.userName).length));
-				if (localStorage.key(i).substring(0, (this.baseName + ":" + this.userName).length) === this.baseName + ":" + this.userName) {
+				if (localStorage.key(i).substring(0, (this.baseName + ":" + this.userName + ":").length) === this.baseName + ":" + this.userName + ":") {
 					arr.push(localStorage.key(i));
 				}
 			}

--- a/src-built-in/adapters/localStorageAdapter.js
+++ b/src-built-in/adapters/localStorageAdapter.js
@@ -80,6 +80,7 @@ const LocalStorageAdapter = function (uuid) {
 
 	/**
 	 * Returns all keys stored in localstorage for the current user, with an optional topic and keyPrefix.
+	 * Note that if topic is not provided, keyPrefix is also ignored.
 	 *
 	 * LocalStorage is synchronous, so the callback is optional (the function
 	 * immediately returns the results if the callback is omitted).

--- a/src-built-in/adapters/localStorageAdapter.js
+++ b/src-built-in/adapters/localStorageAdapter.js
@@ -171,8 +171,7 @@ const LocalStorageAdapter = function (uuid) {
 			let arr = []; // Array to hold the keys
 			// Iterate over localStorage and insert data related to the user into an array.
 			for (let i = 0; i < localStorage.length; i++) {
-				//console.log("localStorage.key(i):::", localStorage.key(i).substring(0, (this.baseName + ":" + this.userName).length));
-        const userKeyBase = this.baseName + ":" + this.userName + ":";
+				const userKeyBase = this.baseName + ":" + this.userName + ":";
 				if (localStorage.key(i).startsWith(userKeyBase)) {
 					arr.push(localStorage.key(i));
 				}

--- a/src-built-in/adapters/localStorageAdapter.js
+++ b/src-built-in/adapters/localStorageAdapter.js
@@ -172,7 +172,8 @@ const LocalStorageAdapter = function (uuid) {
 			// Iterate over localStorage and insert data related to the user into an array.
 			for (let i = 0; i < localStorage.length; i++) {
 				//console.log("localStorage.key(i):::", localStorage.key(i).substring(0, (this.baseName + ":" + this.userName).length));
-				if (localStorage.key(i).substring(0, (this.baseName + ":" + this.userName + ":").length) === this.baseName + ":" + this.userName + ":") {
+        const userKeyBase = this.baseName + ":" + this.userName + ":";
+				if (localStorage.key(i).startsWith(userKeyBase)) {
 					arr.push(localStorage.key(i));
 				}
 			}


### PR DESCRIPTION
fix: #id [18656]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/21/cards/18656/details/)

**Minor improvements to storage adapters**
* As key prefix functions are greedy, ensure trailing `:` is added when generating user prefixes so that clearCache does clear data for `userB` when trying to clear `user`
* Make the topic (and KeyPrefix) optional when calling `keys()`
* Correct some comments

**Description of testing**
1. In the seed project, with default configuration (but with auth enabled), create two users (by logging in as each using the default auth component). Ensure the first user's name is a substring of the second user (e.g. testuser and testuserB).
1. Verify via devtools that data exists in indexeddb for both users.
1. Log in as the first user and test clearing cache with `FSBL.Clients.StorageClient.clearCache();`
    - [ ] Indexeddb will be wiped for both users, which is not the desired behavior.
