### PR TITLE
18351 display name in my apps

### DIFF
--- a/src-built-in/components/myApps/src/components/AppDefinition.jsx
+++ b/src-built-in/components/myApps/src/components/AppDefinition.jsx
@@ -54,7 +54,7 @@ export default class AppDefinition extends React.Component {
 		return (
 			<div onClick={this.onItemClick} className="app-item link" draggable="true" onDragStart={this.onDragToFolder}>
 				<span className="app-item-title">
-					<span >{app.name}</span> {this.isFavorite() && <i className='ff-favorite'></i>}
+					<span >{app.displayName}</span> {this.isFavorite() && <i className='ff-favorite'></i>}
 				</span>
 				{app.tags.length > 0 &&
 					<AppTagsList tags={app.tags} />}

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -202,6 +202,7 @@ function loadInstalledConfigComponents(cb = Function.prototype) {
 					appID: componentName,
 					icon: component.foreign.Toolbar && component.foreign.Toolbar.iconClass ? component.foreign.Toolbar.iconClass : null,
 					name: componentName,
+					displayName: component.component.displayName || componentName,
 					source: "config",
 					tags: extractTagsFromFinsembleComponentConfig(component)
 				};
@@ -289,7 +290,7 @@ function addPin(pin) {
 			if (componentToToggle.component && componentToToggle.component.windowGroup) { params.groupName = componentToToggle.component.windowGroup; }
 			var thePin = {
 				type: "componentLauncher",
-				label: pin.name,
+				label: pin.displayName,
 				component: componentToToggle.group ? componentToToggle.list : componentType,
 				fontIcon: fontIcon,
 				icon: imageIcon,
@@ -459,7 +460,7 @@ function renameFolder(oldName, newName) {
 
 function addAppToFolder(folderName, app) {
 	data.folders[folderName].apps[app.appID] = {
-		name: app.name,
+		name: app.displayName,
 		appID: app.appID
 	};
 	_setFolders();

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -460,7 +460,8 @@ function renameFolder(oldName, newName) {
 
 function addAppToFolder(folderName, app) {
 	data.folders[folderName].apps[app.appID] = {
-		name: app.displayName,
+		name: app.name,
+		displayName: app.displayName,
 		appID: app.appID
 	};
 	_setFolders();

--- a/src-built-in/components/myApps/src/stores/StoreActions.js
+++ b/src-built-in/components/myApps/src/stores/StoreActions.js
@@ -83,7 +83,9 @@ function initialize(callback = Function.prototype) {
 			FSBL.Clients.RouterClient.subscribe("Finsemble.Service.State.launcherService", (err, response) => {
 				loadInstalledComponentsFromStore(() => {
 					//We load our stored components(config driven) here
-					loadInstalledConfigComponents(callback);
+					loadInstalledConfigComponents(() => {
+						updateAppsInFolders(callback);
+					});
 				});
 
 			});
@@ -98,6 +100,23 @@ function getApp(appID, cb = Function.prototype) {
 function appInAppList(appName) {
 	let app = findAppByField('name', appName);
 	return Boolean(app);
+}
+//Update apps in folders with updated config information
+function updateAppsInFolders(cb = Function.prototype) {
+	//Loop through folders and update apps with new info
+	const { MY_APPS: MyAppsFolderName } = getConstants(); 
+	Object.keys(data.folders).map(folderName => {
+		if (folderName === MyAppsFolderName) return;
+		else {
+			const folder = data.folders[folderName];
+			Object.values(data.configComponents).map(configComp => {
+				if (Object.keys(folder.apps).includes(configComp.appID)) {
+					data.folders[folderName].apps[configComp.appID] = configComp;
+				}
+			});
+		}
+	});
+	_setFolders(cb);
 }
 
 /**


### PR DESCRIPTION
fix: #id [18351]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18351/details)

Link with: https://github.com/ChartIQ/finsemble-react-controls/pull/28

**Description of change**
* Added `displayName` to the list of app config items that are pulled into the app launchers store
* Components with no `displayName` property will just use their regular name
* Everywhere where a component's name is displayed, it will instead use the displayName

**Description of testing**
1. Change `componentName.component.displayName` of some of the components to something other than what it currently is/different than the app's actual name
1. Confirm the 'My Apps' section displays the display name.
1. Favorite the app and confirm the pin name is the display name
1. Confirm the favorites folder also displays the app with the display name
1. Confirm putting the app in a folder and showing that folder also displays the displayName
1. Confirm app with displayName launches when clicked
1. Remove displayName altogether and ensure the app still displays properly in the menu
1. [ ] displayName was respected in all places