### PR TITLE
[18518] Fix search results not spawned when clicked on

### DIFF
--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -63,7 +63,7 @@ export default class Search extends React.Component {
 				// which is preventing the onClick handler which from firing.
 				// A search result item's click handler must have the highest priority
 				// otherwise clicking on search results to spawn a component will fail.
-				// I really hate setTimeout, but it shouldn't have any side here.
+				// I really hate setTimeout, but it shouldn't have any side effects here.
 				setTimeout(storeExports.Actions.handleClose, 300)
 			}
 		})

--- a/src-built-in/components/toolbar/components/Search.jsx
+++ b/src-built-in/components/toolbar/components/Search.jsx
@@ -58,7 +58,13 @@ export default class Search extends React.Component {
 	meunBlur() {
 		mouseInElement(this.searchInput.current, function (err, inBounds) {
 			if (!inBounds) {
-				storeExports.Actions.handleClose();
+				// Sometimes storeExports.Actions.handleClose is invoked
+				// before the onClick handler inside searchMenu/componentitem.jsx
+				// which is preventing the onClick handler which from firing.
+				// A search result item's click handler must have the highest priority
+				// otherwise clicking on search results to spawn a component will fail.
+				// I really hate setTimeout, but it shouldn't have any side here.
+				setTimeout(storeExports.Actions.handleClose, 300)
 			}
 		})
 	}


### PR DESCRIPTION
fix: #id 18518

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18518/details)

**Description of change**
* Delayed closing on search results menu

**Description of testing**
1. Checkout this branch and run `npm run dev`
1. Add a new component `Google` and URL `http://google.com`
1. Search for Google in toolbar

- [ ] You should see Google in search results
- [ ] Clicking on Google spawns a google window
- [ ]  Clicking on result still spawns after few attempts 