### PR TITLE
fix: #id 18866 Added FinsembleTransport Config Back in for native components

### DIFF
--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -84,7 +84,12 @@
             "$applicationRoot/configs/application/config.json"
         ],
         "router": {
-            "crossDomainTransport": "IPCBus"
+            "crossDomainTransport": "IPCBus",
+            "transportSettings": {
+                "FinsembleTransport": {
+                    "serverAddress": "ws://127.0.0.1:3376"
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/18866/details)

**Description of change**
* Added FinsembleTransport Config Back in for native components

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Checkout matching Finsemble branch.
1. Add a WPF Component (must use planned/4.0.0 for finsemble-dll)
1. Run Finsemble and WPF Components should work.