### PR TITLE
fix: #id 16510 fix cross component header value issue caused by applications sharing the same cache folder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -578,6 +578,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 			}
 
 			FEAPackager.setFeaPath(FEA_PATH);
+			await FEAPackager.setApplicationFolderName(installerConfig.name);
 			await FEAPackager.setManifestURL(manifestUrl);
 			await FEAPackager.setUpdateURL(updateUrl);
 			await FEAPackager.setChromiumFlags(chromiumFlags || {});


### PR DESCRIPTION
fix: #id 16510

Refer to https://github.com/ChartIQ/finsemble-electron-adapter/pull/171 for details