### PR TITLE
15321 workspace failures

### DIFF
--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -342,7 +342,6 @@ Actions = {
 	 * Asks the user if they'd like to save their data, then loads the requested workspace.
 	 */
 	switchToWorkspace: function (data) {
-		//if (Actions.getIsSwitchingWorkspaces()) return;
 		Actions.setIsSwitchingWorkspaces(true);
 		Actions.blurWindow();
 		let name = data.name;

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -342,7 +342,7 @@ Actions = {
 	 * Asks the user if they'd like to save their data, then loads the requested workspace.
 	 */
 	switchToWorkspace: function (data) {
-		if (Actions.getIsSwitchingWorkspaces()) return;
+		//if (Actions.getIsSwitchingWorkspaces()) return;
 		Actions.setIsSwitchingWorkspaces(true);
 		Actions.blurWindow();
 		let name = data.name;


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/15321/details/)

**Description of change**
* Removed UI restriction that prevents switching workspace before the previous switch is complete. 

See corresponding Finsemble PR: https://github.com/ChartIQ/finsemble/pull/1610  --  **These two PRs must used and merged together.**