### PR TITLE
fix: #id [19305] correct window.options in seed components

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -8,7 +8,6 @@
 				"options": {
 					"resizable": true,
 					"autoShow": true,
-					"backgroundColor": "#22262F",
 					"alwaysOnTop": false
 				},
 				"top": "center",

--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -6,8 +6,12 @@
 				"url": "$applicationRoot/components/welcome/welcome.html",
 				"affinity": "workspaceComponents",
 				"frame": false,
-				"resizable": true,
-				"autoShow": true,
+				"options": {
+					"resizable": true,
+					"autoShow": true,
+					"backgroundColor": "#22262F",
+					"alwaysOnTop": false
+				},
 				"top": "center",
 				"left": "center",
 				"width": 400,
@@ -34,6 +38,7 @@
 						"launchableByUser": true
 					},
 					"Window Manager": {
+						"alwaysOnTopIcon": true,
 						"showLinker": true,
 						"FSBLHeader": true,
 						"persistWindowState": true,
@@ -50,8 +55,10 @@
 				"url": "$applicationRoot/components/nonConfiguredComponent/nonConfiguredComponent.html",
 				"affinity": "systemComponents",
 				"frame": false,
-				"resizable": true,
-				"autoShow": true,
+				"options": {
+					"resizable": true,
+					"autoShow": true
+				},
 				"top": "center",
 				"left": "center",
 				"width": 400,
@@ -63,14 +70,12 @@
 				"windowType": "assimilation",
 				"path": "notepad.exe",
 				"defaultHeight": 600,
-				"autoShow": true,
-				"resizable": true,
+				"options": {
+					"autoShow": true
+				},
 				"showTaskbarIcon": false,
 				"contextMenu": true,
-				"addToWorkspace": true,
-				"options": {
-					"alwaysOnTop": false
-				}
+				"addToWorkspace": true
 			},
 			"component": {
 				"spawnOnHotkey": [

--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -5,7 +5,6 @@
 			"window": {
 				"url": "$applicationRoot/components/welcome/welcome.html",
 				"affinity": "workspaceComponents",
-				"frame": false,
 				"options": {
 					"resizable": true,
 					"autoShow": true,

--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -52,7 +52,6 @@
 			"window": {
 				"url": "$applicationRoot/components/nonConfiguredComponent/nonConfiguredComponent.html",
 				"affinity": "systemComponents",
-				"frame": false,
 				"options": {
 					"resizable": true,
 					"autoShow": true


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/19305/details/)

**Fix Welcome component and other example configs**
* The seed project contained some config options that were not working as they were not in the correct place (e.g. window.autoShow, which should be window.options.autoShow). This misleads clients all the time - particularly as we don't document window.options (we used to rely on OpenFin for this).

**Description of testing**
1. Run the seed project and check the Welcome component is working as normal.
1. Change some of the window.options.* settings (e.g. set `window.options.resizable = false` or `window.options.alwaysOnTop = true`) 
1. Restart Finsemble and see that the specified settings apply to the component correctly.