### PR TITLE
chore: #id 19169 Remove implementation of launchGroups in app launcher

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -144,8 +144,6 @@ const { launch, connect } = require('hadouken-js-adapter');
 
 	// #endregion
 
-	// #region Script variables
-	let watchClose;
 	// If you specify environment variables to child_process, it overwrites all environment variables, including
 	// PATH. So, copy based on our existing env variables.
 	const env = process.env;
@@ -196,7 +194,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 		return rc;
 	}
 
-	
+
 	// Currently supported desktop agents include "openfin" and "electron". This can be set either
 	// with the environment variable container or by command line argument `npx gulp dev --container:electron`
 	let container = envOrArg("container", "openfin");
@@ -216,7 +214,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 	 * deploymentHelpers in FEA. However I'm just avoiding 2 PRs
 	 */
 	const getElectronVersion = () => {
-		// You may run `npm run dev` before running `npm i` inside 
+		// You may run `npm run dev` before running `npm i` inside
 		// finsemble-electron-adapter in that case, the electron
 		// module does not exists.
 		try {
@@ -522,6 +520,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 
 			let config = {
 				manifest: cfg.serverConfig,
+				onElectronClose: process.exit,
 				chromiumFlags: JSON.stringify(cfg.chromiumFlags),
 				path: FEA_PATH,
 			}

--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -169,33 +169,7 @@ var Actions = {
 			}
 		}
 
-		self.componentList = {};
-		// deal with groups
-		for (let componentType in componentList) {
-			let config = components[componentType];
-			let componentGroups = (config.component && config.component.launchGroups) ? config.component.launchGroups : false;
-			if (componentGroups) {
-				if (!Array.isArray(componentGroups)) {
-					componentGroups = [componentGroups];
-				}
-				for (let componentGroup of componentGroups) {
-					if (!self.componentList[componentGroup]) {
-						self.componentList[componentGroup] = {
-							group: componentGroup,
-							list: {}
-						};
-					}
-					self.componentList[componentGroup].list[componentType] = componentList[componentType];
-					if (componentList[componentType].component.windowGroup) {
-						componentList[componentType].params = {
-							groupName: componentList[componentType].component.windowGroup
-						};
-					};
-				}
-			}
-			config.component.type = componentType;
-			self.componentList[componentType] = componentList[componentType];
-		}
+		self.componentList = componentList;
 
 		FSBL.Clients.Logger.debug("appLauncher filterComponents", self.componentList, "settings", settings, "customData", FSBL.Clients.WindowClient.options.customData);
 		appLauncherStore.setValue({ field: "componentList", value: self.componentList });

--- a/src-built-in/preloads/nativeOverrides.js
+++ b/src-built-in/preloads/nativeOverrides.js
@@ -25,10 +25,10 @@
  */
 
 var originalWindowOpen = window.open;
-window.open = function (URL, name, specs, replace) {
+window.open = function (theURL, name, specs, replace) {
 	// For some strange reason, openfin notifications use window.open. So we make an exception for that one case.
 	if (name && name.includes("openfin-child-window")) {
-		originalWindowOpen.call(window, URL, name, specs, replace);
+		originalWindowOpen.call(window, theURL, name, specs, replace);
 		return;
 	}
 	var params = {};
@@ -42,13 +42,13 @@ window.open = function (URL, name, specs, replace) {
 	if (name) {
 		switch (name) {
 			case "_self":
-				location.href = URL;
+				location.href = theURL;
 				return;
 			case "_top":
-				window.top.href = URL;
+				window.top.href = theURL;
 				return;
 			case "_parent":
-				window.parent.href = URL;
+				window.parent.href = theURL;
 				return;
 			case "_blank":
 				break;
@@ -56,7 +56,8 @@ window.open = function (URL, name, specs, replace) {
 				params.name = name;
 		}
 	}
-	params.url = URL;
+	let u = new URL(theURL, window.location);
+	params.url = u.href;
 
 	var w;
 	FSBL.Clients.LauncherClient.spawn(null, params, function (err, response) {


### PR DESCRIPTION
chore: #id [19169]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19169/details)

**Description of change**
* Removed app launcher's implementation of launcherGroups

Finsemble PR required to test: https://github.com/ChartIQ/finsemble/pull/1642

**Description of testing**
1. Add a `launcherGroups` property to two different component's `<name>.component` field, make the value of `launcherGroups` the same for both components.
1. Launch Finsemble
1. Launch both apps and ensure no grouping/simultaneous launching occurs
1. Make sure there is no entry in the `App Launcher` or `My Apps` menu
1. [ ] Everything behaves normally and nothing unexpected was added to the app menus