### PR TITLE
Add server error message for when appd returns no results

### DIFF
--- a/src-built-in/components/appCatalog2/appCatalog.css
+++ b/src-built-in/components/appCatalog2/appCatalog.css
@@ -45,6 +45,16 @@
 	font-family: var(--font-family);
 }
 
+.appMarket .server-error {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 10px;
+	font-size: 12px;
+	line-height: 14px;
+	color: #f26666;
+}
+
 .hero-main {
 	display: flex;
 	flex-direction: row;

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -316,9 +316,9 @@ export default class AppMarket extends React.Component {
 					<div className='server-error'>
 						<br />
 						<br />
-						<span>There are no apps loaded to the catalog.</span>
+						<span>There are no apps available in this catalog.</span>
 						<br />
-						<span>Please consult your System Admin.</span>
+						<span>Please contact your System Admin.</span>
 					</div>
 				}
 				{this.state.apps.length > 0 &&

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -23,6 +23,7 @@ export default class AppMarket extends React.Component {
 		super(props);
 		this.state = {
 			apps: [],
+			isLoading: false,
 			filteredApps: [],
 			installed: [],
 			tags: [],
@@ -53,15 +54,20 @@ export default class AppMarket extends React.Component {
 		//For more information on async react rendering, see here
 		//https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html
 
-		this._asyncAppRequest = storeActions.getApps().then(apps => {
-			this.setState({
-				apps
+		this.setState({
+			isLoading: true
+		}, () => {
+			this._asyncAppRequest = storeActions.getApps().then(apps => {
+				this.setState({
+					apps,
+					isLoading: false
+				});
 			});
-		});
-
-		this._asyncTagsRequest = storeActions.getTags().then(tags => {
-			this.setState({
-				tags
+	
+			this._asyncTagsRequest = storeActions.getTags().then(tags => {
+				this.setState({
+					tags
+				});
 			});
 		});
 	}
@@ -284,12 +290,25 @@ export default class AppMarket extends React.Component {
 
 		return (
 			<div>
-				<SearchBar hidden={page === "showcase" ? true : false} backButton={page !== "home"} tags={tags} activeTags={activeTags} tagSelected={this.addTag}
-					removeTag={this.removeTag} goHome={this.goHome} installationActionTaken={this.state.installationActionTaken}
-					search={this.changeSearch} isViewingApp={this.state.activeApp !== null} />
-				<div className="market_content">
-					{pageContents}
-				</div>
+				{this.state.apps.length === 0 && !this.state.isLoading &&
+					<div className='server-error'>
+						<br />
+						<br />
+						<span>There are no apps loaded to the catalog.</span>
+						<br />
+						<span>Please consult your System Admin.</span>
+					</div>
+				}
+				{this.state.apps.length > 0 &&
+					<div> 
+						<SearchBar hidden={page === "showcase" ? true : false} backButton={page !== "home"} tags={tags} activeTags={activeTags} tagSelected={this.addTag}
+							removeTag={this.removeTag} goHome={this.goHome} installationActionTaken={this.state.installationActionTaken}
+							search={this.changeSearch} isViewingApp={this.state.activeApp !== null} />
+						<div className="market_content">
+							{pageContents}
+						</div>
+					</div>
+				}
 			</div>
 		);
 	}


### PR DESCRIPTION
refactor: #id [19189]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19189/details)

**Description of change**
* Adds error message to app catalog when appd server returns no results

**Description of testing**
1. Pull down PR
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Launcher2` instead of `App Launcher`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Before running the appd, clear `src/data.json` so it returns an empty array: `[]`
1. Run appd with `npm run start`
1. Open the App Directory and ensure a red error message is displayed that looks like: https://app.zeplin.io/project/5a6b7dea31e01cd724fc9f60/screen/5dd83bb92ea20099b1f83f92
1. [ ] Error message was displayed and styled like the mockup