### PR TITLE
fix: #id 19191 search case insensitive

### DIFF
--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -188,7 +188,7 @@ export default class AppMarket extends React.Component {
 	 * @param {string} search The text to search the catalog with
 	 */
 	changeSearch(search) {
-		storeActions.searchApps(search, () => {
+		storeActions.searchApps(search.toLowerCase().trim(), () => {
 
 			this.setState({ forceSearch: (search !== "") });
 		});


### PR DESCRIPTION
fix: #id [19191]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19191/details)

**Description of change**
* Make App Catalog search case insensitive

**Description of testing**
1. Pull down PR
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Launcher2` instead of `App Launcher`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Before running the appd, clear `src/data.json` so it returns an empty array: `[]`
1. Run appd with `npm run start`
1. Open app catalog and perform a search with all lowercase for an app that should definitely return results
1. [ ] App with capital letters in name was returned on search with all lowercase