### PR TITLE
feat: #id 19170 disable hyperfocus

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
@@ -79,14 +79,6 @@ export default class LinkerGroups extends React.Component {
     }
 
     onClick(e, channel) {
-        if (e.shiftKey) {
-            //leaves any docking group.
-            return HeaderActions.hyperFocus({
-                linkerChannel: channel,
-                includeDockedGroups: true,
-                includeAppSuites: false
-            });
-        }
         FSBL.Clients.LinkerClient.bringAllToFront({
             channel: channel,
             restoreWindows: true

--- a/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
@@ -18,6 +18,7 @@ export default class MinimizeButton extends React.Component {
 		windowTitleBarStore = getStore();
 		this.state = { hoverState: "false", show: false, groups: [] };
 		this.onLeftClick = this.onLeftClick.bind(this);
+		this.onShiftClick = this.onShiftClick.bind(this);
 		this.handleClick = this.handleClick.bind(this);
 	}
 
@@ -62,8 +63,17 @@ export default class MinimizeButton extends React.Component {
 		});
 	}
 
-	
+	onShiftClick() {
+		return HeaderActions.hyperFocus({	
+			linkerChannel: null,	
+			includeDockedGroups: true,	
+			includeAppSuites: true	
+		});	
+	}
 	handleClick(e) {
+		if (e.shiftKey) {	
+			return this.onShiftClick(e);	
+		}
 		this.onLeftClick(e);
 	}
 	/**

--- a/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
@@ -64,15 +64,15 @@ export default class MinimizeButton extends React.Component {
 	}
 
 	onShiftClick() {
-		return HeaderActions.hyperFocus({	
-			linkerChannel: null,	
-			includeDockedGroups: true,	
-			includeAppSuites: true	
-		});	
+		return HeaderActions.hyperFocus({
+			linkerChannel: null,
+			includeDockedGroups: true,
+			includeAppSuites: true
+		});
 	}
 	handleClick(e) {
-		if (e.shiftKey) {	
-			return this.onShiftClick(e);	
+		if (e.shiftKey) {
+			return this.onShiftClick(e);
 		}
 		this.onLeftClick(e);
 	}

--- a/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/right/BringSuiteToFront.jsx
@@ -18,7 +18,6 @@ export default class MinimizeButton extends React.Component {
 		windowTitleBarStore = getStore();
 		this.state = { hoverState: "false", show: false, groups: [] };
 		this.onLeftClick = this.onLeftClick.bind(this);
-		this.onShiftClick = this.onShiftClick.bind(this);
 		this.handleClick = this.handleClick.bind(this);
 	}
 
@@ -63,17 +62,8 @@ export default class MinimizeButton extends React.Component {
 		});
 	}
 
-	onShiftClick() {
-		return HeaderActions.hyperFocus({
-			linkerChannel: null,
-			includeDockedGroups: true,
-			includeAppSuites: true
-		});
-	}
+	
 	handleClick(e) {
-		if (e.shiftKey) {
-			return this.onShiftClick(e);
-		}
 		this.onLeftClick(e);
 	}
 	/**

--- a/src-built-in/components/windowTitleBar/src/components/right/DockingButton.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/right/DockingButton.jsx
@@ -77,16 +77,8 @@ export default class DockingButton extends React.Component {
      *
      * @memberof DockingButton
      */
-    onClick(e) {
-        if (this.state.dockingIcon === "ejector" && e.shiftKey) {
-            return HeaderActions.hyperFocus({
-                linkerChannel: null,
-                includeDockedGroups: true,
-                includeAppSuites: false
-            });
-        } else {
-    		HeaderActions.toggleGroup();
-        }
+    onClick(e) {        
+		HeaderActions.toggleGroup();
 	}
 
     /**

--- a/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
+++ b/src-built-in/components/windowTitleBar/src/stores/windowTitleBarStore.js
@@ -277,92 +277,11 @@ var Actions = {
 		}
 		return myGroups;
 	},
-	hyperFocus: function (params = {}) {
-
-		function getLinkedWindows(callback) {
-			FSBL.Clients.LinkerClient.getLinkedComponents({ channels: [linkerChannel] }, (err, data) => {
-				let windows = data.map((win) => win.windowName);
-				windowList = windowList.concat(windows);
-				callback();
-			});
-		}
-
-		function getDockedWindows(callback) {
-			function getWindows(groupName, done) {
-				FSBL.Clients.RouterClient.query("DockingService.getWindowsInGroup", { groupName }, (err, response) => {
-					windowList = windowList.concat(response.data);
-					done();
-				});
-			}
-
-			//Get the windows for every list.
-			async.forEach(dockingGroups, getWindows, callback);
-		}
-
-		function getWindowsInAppSuite(callback) {
-			FSBL.Clients.LauncherClient.getGroupsForWindow((err, data) => {
-				function getWindowsInGroup(group, done) {
-					FSBL.Clients.RouterClient.query("LauncherService.getWindowsInGroup", { groupName: group }, (err, response) => {
-						windowList = windowList.concat(response.data);
-						done();
-					});
-				}
-				if (err) return callback(err, null);
-				let groups = data;
-				if (groups) {
-					async.forEach(groups, getWindowsInGroup, callback);
-				} else {
-					callback(null, null);
-				}
-			});
-		}
-
-
-		let { linkerChannel, includeAppSuites, includeDockedGroups } = params;
-		let windowList = [],
-			tasks = [],
-			dockingGroups = [],
-			isGrouped = windowTitleBarStore.getValue({ field: "isGrouped" }),
-			movableGroups = windowTitleBarStore.getValue({ field: "Main.allMovableDockingGroups" });
-
-
-		if (linkerChannel) {
-			tasks.push(getLinkedWindows);
-		}
-
-		if (includeDockedGroups && isGrouped) {
-			dockingGroups = windowTitleBarStore.getValue({ field: "Main.dockingGroups" });
-			if (dockingGroups) {
-				dockingGroups = dockingGroups.filter(grp => grp.isMovable).map(grp => grp.groupName);
-				tasks.push(getDockedWindows);
-			}
-		}
-
-		if (includeAppSuites) {
-			tasks.push(getWindowsInAppSuite);
-		}
-
-		if (tasks.length) {
-			async.parallel(tasks, () => {
-				windowList.forEach(windowName => {
-					movableGroups.forEach((grp) => {
-						if (grp.windowNames.includes(windowName)) {
-							windowList = windowList.concat(grp.windowNames);
-						}
-					});
-				});
-				FSBL.Clients.LauncherClient.hyperFocus({ windowList });
-			});
-		}
-	},
 	onTabListScrollPositionChanged: function (err, response) {
 		windowTitleBarStore.setValue({ field: "tabListTranslateX", value: response.data.translateX });
 	},
 	setTabListScrollPosition: function (translateX) {
 		FSBL.Clients.RouterClient.transmit(constants.TAB_SCROLL_POSITION_CHANGED, { translateX });
-	},
-	hyperfocusDockingGroup: function () {
-		FSBL.Clients.RouterClient.transmit("DockingService.hyperfocusGroup", { windowName: FSBL.Clients.WindowClient.getWindowNameForDocking() });
 	},
 	/**
 	 * Handles messages coming from the windowClient.


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19170/details)

**Description of change**
* Removed all code in the seed that called or implemented hyperfocus

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Verified Finsemble starts
1. Verified shift-clicking on a channel no longer triggers the hyperfocus action (all other windows in a different channel minimize). It may still be treated the same as a regular left-click.