### PR TITLE
chore: #id 19410 Remove reliance on fin API and call the Finsemble API instead

### DIFF
--- a/src-built-in/components/toolbar/components/DragHandle.jsx
+++ b/src-built-in/components/toolbar/components/DragHandle.jsx
@@ -3,13 +3,13 @@ import { ReactComponent as DragHandleIcon } from '../../../../assets/img/toolbar
 
 
 const DragHandle = () => {
-	const currentWindow = fin.desktop.Window.getCurrent();
 	const handleMouseDown = (event) => {
-		currentWindow.startMovingWindow(event);
+		FSBL.Clients.WindowClient.startMovingWindow(event);
 	};
-	const handleMouseUp = (event) => {
-		currentWindow.stopMovingWindow(event);
+	const handleMouseUp = () => {
+		FSBL.Clients.WindowClient.stopMovingWindow();
 	};
+
 	return (
 		<span className="cq-drag finsemble-toolbar-drag-handle"
 			onMouseDown={handleMouseDown}


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19410/details)

**Description of change**
* Add startMovingWindow and stopMovingWindow API methods to the windowClient.

**Description of testing**
1. Start finsemble.
2. Move windows around quickly.
3. Move windows around slowly.