### PR TITLE
19168 disable auto arrange

### DIFF
--- a/src-built-in/components/toolbar/components/AutoArrange.jsx
+++ b/src-built-in/components/toolbar/components/AutoArrange.jsx
@@ -68,7 +68,7 @@ export default class AutoArrange extends React.Component {
 
 	render() {
 		// For 4.0 auto-arrange is disabled -- it will be re-enabled in a future release after it is improved and hardened.
-		// However, keep it easy to re-enable by setting AutoArrangeEnabled=true -- this should only be done in-house to simply testing with a large number of windows
+		// However, keep it easy to re-enable by setting AutoArrangeEnabled=true -- this should only be done for in-house testing with a large number of windows
 		const AutoArrangeEnabled = false;
 
 		if (AutoArrangeEnabled) {

--- a/src-built-in/components/toolbar/components/AutoArrange.jsx
+++ b/src-built-in/components/toolbar/components/AutoArrange.jsx
@@ -67,8 +67,7 @@ export default class AutoArrange extends React.Component {
 	}
 
 	render() {
-		// For 4.0 auto-arrange is disabled -- it will be re-enabled in a future release after it is improved and hardened.
-		// However, keep it easy to re-enable by setting AutoArrangeEnabled=true -- this should only be done for in-house testing with a large number of windows
+		// To re-enable auto-arrange set AutoArrangeEnabled=true -- this should only be done for in-house testing
 		const AutoArrangeEnabled = false;
 
 		if (AutoArrangeEnabled) {

--- a/src-built-in/components/toolbar/components/AutoArrange.jsx
+++ b/src-built-in/components/toolbar/components/AutoArrange.jsx
@@ -67,19 +67,28 @@ export default class AutoArrange extends React.Component {
 	}
 
 	render() {
-		const autoArrangedCss = this.state.isAutoArranged ? "auto-arranged" : "";
+		// For 4.0 auto-arrange is disabled -- it will be re-enabled in a future release after it is improved and hardened
+		const AutoArrangeEnabled = false;
 
+		if (AutoArrangeEnabled) {
+			const autoArrangedCss = this.state.isAutoArranged ? "auto-arranged" : "";
 
-		return (
-			<FinsembleButton
-				className={`icon-only window-mgmt-right ${autoArrangedCss}`}
-				buttonType={["Toolbar"]}
-				title={this.state.isAutoArranged ? "Restore" : "Auto Arrange"}
-				onClick={this.autoArrange}>
-				<span>
-					<AutoArrangeIcon />
-				</span>
-			</FinsembleButton>
-		);
+			// the below enables AutoArrange by returning the AutoArrange icon to be rendered
+			return (
+				<FinsembleButton
+					className={`icon-only window-mgmt-right ${autoArrangedCss}`}
+					buttonType={["Toolbar"]}
+					title={this.state.isAutoArranged ? "Restore" : "Auto Arrange"}
+					onClick={this.autoArrange}>
+					<span>
+						<AutoArrangeIcon />
+					</span>
+				</FinsembleButton>
+			);
+		} else {
+			// the below effectively disables AutoArrange by returning an empty div to be rendered for the auto-arrange icon
+			return (<div></div>);
+		}
+
 	}
 }

--- a/src-built-in/components/toolbar/components/AutoArrange.jsx
+++ b/src-built-in/components/toolbar/components/AutoArrange.jsx
@@ -67,7 +67,8 @@ export default class AutoArrange extends React.Component {
 	}
 
 	render() {
-		// For 4.0 auto-arrange is disabled -- it will be re-enabled in a future release after it is improved and hardened
+		// For 4.0 auto-arrange is disabled -- it will be re-enabled in a future release after it is improved and hardened.
+		// However, keep it easy to re-enable by setting AutoArrangeEnabled=true -- this should only be done in-house to simply testing with a large number of windows
 		const AutoArrangeEnabled = false;
 
 		if (AutoArrangeEnabled) {

--- a/src-built-in/components/toolbar/components/BringToFront.jsx
+++ b/src-built-in/components/toolbar/components/BringToFront.jsx
@@ -12,7 +12,7 @@ const BringToFront = (props) => {
 			ToolbarStore.bringToolbarToFront();
 		});
 	}
-	let wrapperClasses = props.classes + " icon-only window-mgmt-center";
+	let wrapperClasses = props.classes + " icon-only window-mgmt-right";
 
 	return (
 		<FinsembleButton className={wrapperClasses} buttonType={["Toolbar"]} title="Reveal All" onClick={BringToFront}>


### PR DESCRIPTION
fix #id 19168

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19168/details/)

**Description of change**
* Disable/Hide auto-arrange icon to disable auto arrange, but kept it easy to re-enable since used in testing large workspaces

**Description of testing**
Confirmed auto-arrange icon is no longer visible (when AutoArrangeEnabled = false);

