### PR TITLE
chore: #id 19190 Add generic server error message

### DIFF
--- a/src-built-in/components/appCatalog2/appCatalog.css
+++ b/src-built-in/components/appCatalog2/appCatalog.css
@@ -45,6 +45,16 @@
 	font-family: var(--font-family);
 }
 
+.appMarket .server-error {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	padding: 10px;
+	font-size: 12px;
+	line-height: 14px;
+	color: #f26666;
+}
+
 .hero-main {
 	display: flex;
 	flex-direction: row;

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -58,11 +58,11 @@ export default class AppMarket extends React.Component {
 			this.setState({
 				apps
 			});
-		}).catch(() => {
+		}).catch((err) => {
 			this.setState({
 				serverError: true
 			}, () => {
-				FSBL.Clients.Logger.error("Error connecting to FDC3 AppD server.");
+				FSBL.Clients.Logger.error("Error connecting to FDC3 AppD server.", err);
 			});
 		});
 
@@ -70,11 +70,11 @@ export default class AppMarket extends React.Component {
 			this.setState({
 				tags
 			});
-		}).catch(() => {
+		}).catch((err) => {
 			this.setState({
 				serverError: true
 			}, () => {
-				FSBL.Clients.Logger.error("Error retrieving tags from FDC3 AppD server.");
+				FSBL.Clients.Logger.error("Error retrieving tags from FDC3 AppD server.", err);
 			});
 		});
 	}

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -61,6 +61,8 @@ export default class AppMarket extends React.Component {
 		}).catch(() => {
 			this.setState({
 				serverError: true
+			}, () => {
+				FSBL.Clients.Logger.error("Error connecting to FDC3 AppD server.");
 			});
 		});
 
@@ -71,6 +73,8 @@ export default class AppMarket extends React.Component {
 		}).catch(() => {
 			this.setState({
 				serverError: true
+			}, () => {
+				FSBL.Clients.Logger.error("Error retrieving tags from FDC3 AppD server.");
 			});
 		});
 	}

--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -24,6 +24,7 @@ export default class AppMarket extends React.Component {
 		this.state = {
 			apps: [],
 			filteredApps: [],
+			serverError: false,
 			installed: [],
 			tags: [],
 			activeTags: [],
@@ -57,11 +58,19 @@ export default class AppMarket extends React.Component {
 			this.setState({
 				apps
 			});
+		}).catch(() => {
+			this.setState({
+				serverError: true
+			});
 		});
 
 		this._asyncTagsRequest = storeActions.getTags().then(tags => {
 			this.setState({
 				tags
+			});
+		}).catch(() => {
+			this.setState({
+				serverError: true
 			});
 		});
 	}
@@ -89,11 +98,11 @@ export default class AppMarket extends React.Component {
 		FSBL.Clients.RouterClient.removeListener("viewApp", this.viewApp);
 
 		//Make sure async requests have finished.
-		if (this._asyncAppRequest) {
+		if (this._asyncAppRequest && this._asyncAppRequest.cancel) {
 			this._asyncAppRequest.cancel();
 		}
 
-		if (this._asyncTagsRequest) {
+		if (this._asyncTagsRequest && this._asyncTagsRequest.cancel) {
 			this._asyncTagsRequest.cancel();
 		}
 	}
@@ -130,7 +139,7 @@ export default class AppMarket extends React.Component {
 		let apps = storeActions.getFilteredApps();
 		let tags = storeActions.getActiveTags();
 
-		//Make sure a change actually occured before rerendering. If the store's activeTags or filteredApps is different then component's, we make a change (which triggers a page change). Otherwise don't.
+		//Make sure a change actually occurred before re-rendering. If the store's activeTags or filteredApps is different then component's, we make a change (which triggers a page change). Otherwise don't.
 		//NOTE: The potential bug here is if filteredApps or activeTags has somehow changed and maintained the same length (which should be impossible)
 		if ((apps && filteredApps && activeTags && tags) && (apps.length !== filteredApps.length || activeTags.length !== tags.length)) {
 			this.setState({
@@ -194,7 +203,7 @@ export default class AppMarket extends React.Component {
 		});
 	}
 	/**
-	 * When the notification for isntalling/removing an app is shown a timeout is set to call this function to cease showing the notification
+	 * When the notification for installing/removing an app is shown a timeout is set to call this function to cease showing the notification
 	 */
 	stopShowingInstalledNotification() {
 		this.setState({
@@ -222,7 +231,7 @@ export default class AppMarket extends React.Component {
 		}
 	}
 	/**
-	 * Compiles a list of apps that are installed from the information recieved back from appd
+	 * Compiles a list of apps that are installed from the information received back from appd
 	 * and the information contained on the system
 	 * TODO: This is temporary. It will change when there is actually a way to know from launcher what apps are installed, and which are not
 	 * @param {boolean} filtered If true, uses the filtered apps array. Otherwise uses all apps
@@ -284,12 +293,25 @@ export default class AppMarket extends React.Component {
 
 		return (
 			<div>
-				<SearchBar hidden={page === "showcase" ? true : false} backButton={page !== "home"} tags={tags} activeTags={activeTags} tagSelected={this.addTag}
-					removeTag={this.removeTag} goHome={this.goHome} installationActionTaken={this.state.installationActionTaken}
-					search={this.changeSearch} isViewingApp={this.state.activeApp !== null} />
-				<div className="market_content">
-					{pageContents}
-				</div>
+				{this.state.serverError && 
+					<div className='server-error'>
+						<br />
+						<br />
+						<span>Catalog contents are currently unavailable.</span>
+						<br />
+						<span>Please check your connection or consult your System Admin.</span>
+					</div>
+				}
+				{this.state.apps.length > 0 &&
+					<div>
+						<SearchBar hidden={page === "showcase" ? true : false} backButton={page !== "home"} tags={tags} activeTags={activeTags} tagSelected={this.addTag}
+						removeTag={this.removeTag} goHome={this.goHome} installationActionTaken={this.state.installationActionTaken}
+						search={this.changeSearch} isViewingApp={this.state.activeApp !== null} />
+						<div className="market_content">
+							{pageContents}
+						</div>
+					</div>
+				}
 			</div>
 		);
 	}

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -151,10 +151,12 @@ function _clearActiveTags() {
  */
 async function getApps() {
 	let apps = await appd.getAll((err, apps) => {
-		getStore().setValue({
-			field: "apps",
-			value: apps
-		});
+		if (!err) {
+			getStore().setValue({
+				field: "apps",
+				value: apps
+			});
+		}
 	});
 	return apps;
 }


### PR DESCRIPTION
feat: #id [19190]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19190/details)

**Description of change**
* Adds generic server error message when appd server responds with an error

**Description of testing**
1. Pull down PR
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Launcher2` instead of `App Launcher`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Before running the appd, open `src/controllers/v1/AppsController.js` and change `res.status(200).json(payload)` to `res.status(500).send(new Error("Generic error"))`. This will make it so an error is always returned when polling for apps.
1. Run appd with `npm run start`
1. Open the App Directory and ensure a red error message is displayed that looks like: https://app.zeplin.io/project/5a6b7dea31e01cd724fc9f60/screen/5dd83af2da6799944ab04387
1. [ ] Error message was displayed and styled like the mockup