### PR TITLE
Fix pagination bubbles. Limit to 10, if more than 10 apps, don't show.

### DIFF
--- a/src-built-in/components/appCatalog2/src/components/Hero.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Hero.jsx
@@ -84,13 +84,16 @@ export default class Hero extends Component {
 					</div>
 					<i className='ff-adp-chevron-right' onClick={this.changePage.bind(this, 'page_up')} />
 				</div>
-				<div className="paginator">
-					{cards.map((card, i) => {
-						let classes = 'pagination-oval';
-						if (i === active) classes += " active";
-						return (<div key={i} className={classes} onClick={this.changePage.bind(this, i)} />);
-					})}
-				</div>
+				<br />
+				{cards.length >= 2 && cards.length <= 10 && 
+					<div className="paginator">
+						{cards.map((card, i) => {
+							let classes = 'pagination-oval';
+							if (i === active) classes += " active";
+							return (<div key={i} className={classes} onClick={this.changePage.bind(this, i)} />);
+						})}
+					</div>
+				}
  			</div>
 		);
 	}

--- a/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
+++ b/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
@@ -37,34 +37,29 @@ class SearchBar extends Component {
 		this.toggleTagSelector = this.toggleTagSelector.bind(this);
 		this.selectTag = this.selectTag.bind(this);
 		this.removeTag = this.removeTag.bind(this);
-		this.clearSearch = this.clearSearch.bind(this);
 		this.focus = this.focus.bind(this);
 	}
-	componentWillReceiveProps(nextProps) {
-		if ((nextProps.activeTags.length === 0 && !nextProps.backButton) || nextProps.isViewingApp) {
-			//this.setState({
-			//	searchValue: ""
-			//});
-		}
-	}
+
 	/**
 	 * Handles changing the component state for handling local input value. Also calls parent function to effect the store
 	 * @param {object} e React Synthetic event
 	 */
 	changeSearch(e) {
+		const { value : searchTerms } = e.target;
 		this.setState({
-			searchValue: e.target.value
+			searchValue: searchTerms
 		});
-		this.props.search(e.target.value);
+
+		if (searchTerms !== "") {
+			this.props.search(searchTerms);
+		} else {
+			let tags = storeActions.getActiveTags();
+
+			storeActions.removeTag(tag);
+			storeActions.addTag(tag);
+		}
 	}
 
-	clearSearch() {
-		this.setState({
-			searchValue: ''
-		});
-		this.props.search({ field: 'filteredApps', value: null })
-		this.focus();
-	}
 	/**
 	 * Opens/hides the tag selection menu
 	 */


### PR DESCRIPTION
fix: #id [19477]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19477/details)

**Description of change**
* If number of apps is less than 2 or greater than 10 don't show the pagination bubbles on the Hero component for App Catalog

**Description of testing**
1. Pull down PR
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Launcher2` instead of `App Launcher`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Run `npm i`
1. Navigate to `src/` and open `data.json`. Ensure the number of apps is 10 or more.
1. Run appd with `npm run start`
1. Run Finsemble
1. Open App Catalog
1. [ ] No pagination bubbles appear
1. Change `data.json` on the appd to have 1 app and restart the server
1. [ ] No pagination bubbles appear
1. The bubbles should still be gone
1. Change `data.json` on the appd server to have a number of apps thats greater than 1 and less than 11 and restart the server
1. Reload App Catalog
1. [ ] Pagination bubbles appear