### PR TITLE
Changes to research tags when active tag search combo with text search

### DIFF
--- a/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
+++ b/src-built-in/components/appCatalog2/src/components/SearchBar.jsx
@@ -55,7 +55,12 @@ class SearchBar extends Component {
 		this.setState({
 			searchValue: e.target.value
 		});
-		this.props.search(e.target.value);
+
+		if (searchTerms !== "") {
+			this.props.search(searchTerms);
+		} else {
+			storeActions.refreshTagSearch();
+		}
 	}
 
 	clearSearch() {

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -16,6 +16,7 @@ export default {
 	getTags,
 	addTag,
 	removeTag,
+	refreshTagSearch,
 	clearTags,
 	addApp,
 	removeApp,
@@ -132,6 +133,27 @@ function _removeActiveTag(tag) {
 		value: newActiveTags
 	}, {
 		field: "filteredApps",
+		value: newApps
+	}]);
+}
+
+function _refreshTags() {
+	let { activeTags, apps } = data;
+
+	let newApps = apps.filter((app) => {
+		for (let i = o; i < activeTags.length; i++) {
+			const tag = activeTags[i].trim();
+			if (app.tags.includes(tag)) {
+				return true;
+			}
+		}
+	});
+
+	getStore().setValues([{
+		field: 'activeTags',
+		value: activeTags
+	}, {
+		field: 'filteredApps',
 		value: newApps
 	}]);
 }
@@ -389,6 +411,13 @@ function addTag(tag) {
  */
 function removeTag(tag) {
 	_removeActiveTag(tag);
+}
+
+/**
+ * Refreshes the active tags search
+ */
+function refreshTagSearch() {
+	_refreshTags();
 }
 
 /**


### PR DESCRIPTION
fix: #id [19469]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19469/details)

**Description of change**
* When text is cleared but tags are still active, the search results are repopulated

**Description of testing**
1. Pull down PR
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Catalog2` instead of `App Catalog`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Run `npm i`
1. Navigate to `src/` and open `data.json`. Ensure the number of apps is 10 or more.
1. Run appd with `npm run start`
1. Run Finsemble
1. Open App Catalog
1. Add a tag to search with the tag menu
1. Type in some search text
1. Remove the text
1. [x] Listed results should be all apps containing the tags being filtered on