### PR TITLE
19461 add remove app status not updating

### DIFF
--- a/src-built-in/components/appCatalog2/src/app.jsx
+++ b/src-built-in/components/appCatalog2/src/app.jsx
@@ -236,17 +236,15 @@ export default class AppMarket extends React.Component {
 			apps = this.state.apps;
 		}
 
-		apps = apps.map((app) => {
-			for (let i = 0; i < installed.length; i++) {
-				if (installed.includes(app.appId)) {
-					app.installed = true;
-				} else {
-					app.installed = false;
-				}
+		return apps.map((app) => {
+			if (installed.includes(app.appId)) {
+				app.installed = true;
+			} else {
+				app.installed = false;
 			}
+
 			return app;
 		});
-		return apps;
 	}
 	getPageContents() {
 		let { filteredApps, activeTags } = this.state;

--- a/src-built-in/components/appCatalog2/src/components/AppCard.jsx
+++ b/src-built-in/components/appCatalog2/src/components/AppCard.jsx
@@ -78,7 +78,7 @@ class AppCard extends Component {
 	 */
 	hideCheck() {
 		//Don't hide if installed. Stay green and showing
-		if (this.props.installed === false) {
+		if (!this.props.installed) {
 			this.setState({
 				checkShown: false
 			});
@@ -121,10 +121,10 @@ class AppCard extends Component {
 	render() {
 		let imageUrl = this.props.images !== undefined ? this.props.images[0].url : "../assets/placeholder.svg";
 
-		let { appName, checkShown } = this.state;
+		let { appName, checkShown, checkHighlighted } = this.state;
 
 		let imageIconClasses = "ff-check-mark-2";
-		if (this.state.checkHighlighted || this.props.installed) imageIconClasses += " highlighted"
+		if (this.props.installed || checkHighlighted) imageIconClasses += " highlighted"
 		else imageIconClasses += " faded";
 
 		let titleClass = this.state.titleUnderlined ? "app-title highlighted" : "app-title";

--- a/src-built-in/components/appCatalog2/src/components/AppCard.jsx
+++ b/src-built-in/components/appCatalog2/src/components/AppCard.jsx
@@ -20,6 +20,8 @@ class AppCard extends Component {
 		this.state = {
 			checkShown: this.props.installed === true ? true : false,
 			checkHighlighted: false,
+			awaitingInstall: false,
+			toggleCheckAfterAction: false,
 			titleUnderlined: false,
 			appName: this.props.title || this.props.name,
 			id: this.props.appId,
@@ -77,11 +79,18 @@ class AppCard extends Component {
 	 * Hides the check mark for adding/removing an app
 	 */
 	hideCheck() {
-		//Don't hide if installed. Stay green and showing
-		if (!this.props.installed) {
+		if (this.state.awaitingInstall) {
+			// If an add/remove is taking place and this is called, toggle the check after the action completes
 			this.setState({
-				checkShown: false
+				toggleCheckAfterAction: true
 			});
+		} else {
+			//Don't hide if installed. Stay green and showing
+			if (!this.props.installed) {
+				this.setState({
+					checkShown: false
+				});
+			}
 		}
 	}
 	/**
@@ -97,7 +106,15 @@ class AppCard extends Component {
 	addApp(e) {
 		e.preventDefault();
 		e.stopPropagation();
-		storeActions.addApp(this.state.id);
+		this.setState({
+			awaitingInstall: true
+		}, () => {
+			storeActions.addApp(this.state.id, (err) => {
+				this.setState({
+					awaitingInstall: false
+				});
+			});
+		});
 	}
 	/**
 	 * Prevents bubbling (which would open the app showcase), then calls to remove an app
@@ -106,7 +123,23 @@ class AppCard extends Component {
 	removeApp(e) {
 		e.preventDefault();
 		e.stopPropagation();
-		storeActions.removeApp(this.state.id);
+		this.setState({
+			awaitingInstall: true
+		}, () => {
+			storeActions.removeApp(this.state.id, (err) => {
+				if (this.state.toggleCheckAfterAction) {
+					this.setState({
+						awaitingInstall: false,
+						toggleCheckAfterAction: false,
+						checkShown: !this.state.checkShown
+					});
+				} else {
+					this.setState({
+						awaitingInstall: false
+					});
+				}
+			});
+		});
 	}
 	/**
 	 * Prevents bubbling (which would open the app showcase), then calls to add a filtering tag

--- a/src-built-in/components/appCatalog2/src/components/Showcase/Header.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Showcase/Header.jsx
@@ -49,10 +49,6 @@ const Header = props => {
 		storeActions.removeApp(props.appId);
 	};
 
-	const launchApp = () => {
-
-	};
-	console.log("addApp", props);
 	return (
 		<div className="header">
 			<div className='icon-title-container'>

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -176,7 +176,7 @@ async function getTags() {
  * Function to "install" an app. Adds the id to a list of installed apps
  * @param {string} name The name of the app
  */
-async function addApp(id) {
+async function addApp(id, cb = Function.prototype) {
 	let { activeApp, installed, apps } = data;
 	const appID = id;
 	let app = apps.find(app => {
@@ -253,7 +253,7 @@ async function addApp(id) {
 				field: "appFolders.folders",
 				value: folders
 			}
-		]);
+		], cb);
 	});
 }
 
@@ -261,7 +261,7 @@ async function addApp(id) {
  * Function to "uninstall" an app. Removes the id from a list of installed apps
  * @param {string} name The name of the app
  */
-function removeApp(id) {
+function removeApp(id, cb = Function.prototype) {
 	let { installed, folders } = data;
 
 	ToolbarStore.removeValue({ field: "pins." + installed[id].name.replace(/[.]/g, "^DOT^") }, (err, res) => {
@@ -293,7 +293,7 @@ function removeApp(id) {
 					field: "appFolders.folders",
 					value: folders
 				}
-			]);
+			], cb);
 		});
 	});
 }

--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -193,7 +193,7 @@ async function addApp(id) {
 	installed[appID] = {
 		appID,
 		tags: app.tags,
-		name: app.title ? app.title : app.name,
+		name: app.title || app.name,
 		url: app.url,
 		type: "component",
 		component: {},
@@ -206,7 +206,7 @@ async function addApp(id) {
 					"launchableByUser": true
 				},
 				"Window Manager": {
-					title: app.title ? app.title : app.name
+					title: app.title || app.name
 				}
 			}
 		}
@@ -255,28 +255,6 @@ async function addApp(id) {
 			}
 		]);
 	});
-	/*FSBL.Clients.LauncherClient.addUserDefinedComponent(installed[appID], (compAddErr) => {
-		if (compAddErr && compAddErr.indexOf('already exists') === -1) {
-            //TODO: We need to handle the error here. If the component failed to add, we should probably fall back and not add to launcher
-            console.log('componentAddErr: ', compAddErr);
-			console.warn("Failed to add new app");
-        } else {
-            getStore().setValues([
-                {
-                    field: 'activeApp',
-                    value: activeApp
-                },
-                {
-                    field: 'appDefinitions',
-                    value: installed
-                },
-                {
-                    field: 'appFolders.folders',
-                    value: folders
-                }
-            ]);
-        }
-	});*/
 }
 
 /**
@@ -291,26 +269,32 @@ function removeApp(id) {
 			console.warn("Error removing pin for deleted app");
 			return;
 		}
-		FSBL.Clients.LauncherClient.unRegisterComponent({ componentType: installed[id].name });
-		for (const key in data.folders) {
-			if (folders[key].apps[id]) {
-				delete folders[key].apps[id];
+		FSBL.Clients.LauncherClient.unRegisterComponent({ componentType: installed[id].name }, (err, res) => {
+			if (err) {
+				console.warn("Failed to deregister a component");
+				return;
 			}
-		}
 
-		//Delete the app from the list
-		delete installed[id];
-
-		getStore().setValues([
-			{
-				field: "appDefinitions",
-				value: installed
-			},
-			{
-				field: "appFolders.folders",
-				value: folders
+			for (const key in data.folders) {
+				if (folders[key].apps[id]) {
+					delete folders[key].apps[id];
+				}
 			}
-		]);
+	
+			//Delete the app from the list
+			delete installed[id];
+	
+			getStore().setValues([
+				{
+					field: "appDefinitions",
+					value: installed
+				},
+				{
+					field: "appFolders.folders",
+					value: folders
+				}
+			]);
+		});
 	});
 }
 


### PR DESCRIPTION
fix: #id [19461]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19461/details)

**Description of change**
* Fixed app status building to simplify loop and reduce delay which solved the added/removed status issue

**Description of testing**
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Catalog2` instead of `App Catalog`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Run `npm i`
1. Navigate to `src/` and open `data.json`. Ensure the number of apps is 10 or more.
1. Run appd with `npm run start`
1. Run Finsemble
1. Open App Catalog
1. Click the check box in a Carousel's App Card and the check should switch to green (may have to mouse on/off to update)
1. [x] Check mark switched to green to indicate addition
1. Click again and the check should go back to gray (may have to mouse on/off to update)
1. [x] Check mark went back to gray to indicate the app is not added
1. Open an app showcase (click on an app's app card)
1. Click the blue 'Add' button and it should change to an 'Open' button and a trash can
1. [x] Add button became 'Open' button and trash can
1. Click the trash can to remove it and it should switch back to an 'Add' button
1. [x] Removal buttons changed back to add button