### PR TITLE
Add fdc3 app's friendlyName as component displayName

### DIFF
--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -231,6 +231,11 @@ async function addApp(id) {
 	if (typeof app.manifest !== "object") {
 		appConfig.manifest = { ...appConfig };
 	}
+
+	if (app.friendlyName) {
+		appConfig.displayName = app.friendlyName;
+	}
+
 	let MY_APPS = data.defaultFolder;
 	let folders = data.folders;
 


### PR DESCRIPTION
fix: #id [19424]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19424/details)

**Description of change**
* When adding an app, if it has a friendlyName, apply that to the appConfig.displayName that's passed to the launcher

**Description of testing**
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Catalog2` instead of `App Catalog`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Run `npm i`
1. Run appd with `npm run start`
1. Run Finsemble
1. Open App Catalog
1. [x] Add apps and make sure there is never a blank name field in the app launcher