### PR TITLE
Add check toggle delay to await add/remove action

### DIFF
--- a/src-built-in/components/appCatalog2/src/stores/storeActions.js
+++ b/src-built-in/components/appCatalog2/src/stores/storeActions.js
@@ -176,7 +176,7 @@ async function getTags() {
  * Function to "install" an app. Adds the id to a list of installed apps
  * @param {string} name The name of the app
  */
-async function addApp(id) {
+async function addApp(id, cb = Function.prototype) {
 	let { activeApp, installed, apps } = data;
 	const appID = id;
 	let app = apps.find(app => {
@@ -253,37 +253,15 @@ async function addApp(id) {
 				field: "appFolders.folders",
 				value: folders
 			}
-		]);
+		], cb);
 	});
-	/*FSBL.Clients.LauncherClient.addUserDefinedComponent(installed[appID], (compAddErr) => {
-		if (compAddErr && compAddErr.indexOf('already exists') === -1) {
-            //TODO: We need to handle the error here. If the component failed to add, we should probably fall back and not add to launcher
-            console.log('componentAddErr: ', compAddErr);
-			console.warn("Failed to add new app");
-        } else {
-            getStore().setValues([
-                {
-                    field: 'activeApp',
-                    value: activeApp
-                },
-                {
-                    field: 'appDefinitions',
-                    value: installed
-                },
-                {
-                    field: 'appFolders.folders',
-                    value: folders
-                }
-            ]);
-        }
-	});*/
 }
 
 /**
  * Function to "uninstall" an app. Removes the id from a list of installed apps
  * @param {string} name The name of the app
  */
-function removeApp(id) {
+function removeApp(id, cb = Function.prototype) {
 	let { installed, folders } = data;
 
 	ToolbarStore.removeValue({ field: "pins." + installed[id].name.replace(/[.]/g, "^DOT^") }, (err, res) => {
@@ -310,7 +288,7 @@ function removeApp(id) {
 				field: "appFolders.folders",
 				value: folders
 			}
-		]);
+		], cb);
 	});
 }
 


### PR DESCRIPTION
fix: #id [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/CARD/details)

**Description of change**
* Add toggle delay for check if toggled in the middle of an add/remove action taking place

**Description of testing**
1. In `configs/application/config.json` change `appDirectoryEndpoint` to `http://localhost:3030/v1/`
1. In `src-built-in/components/myApps/src/components/LeftNavBottomLinks.jsx` change `bottomEntries` at the top of the file and uncomment `{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }`
1. In `src-built-in/components/myApps/src/index.jsx` change `openMarketApp`'s call to LauncherClient.showWindow to launch `App Launcher2` instead of `App Launcher`
1. Check out the local appd: https://github.com/ChartIQ/fdc-appd
1. Run `npm i`
1. Navigate to `src/` and open `data.json`. Ensure the number of apps is 10 or more.
1. Run appd with `npm run start`
1. Run Finsemble
1. Open App Catalog
1. Click the check on an App Card to add an app and immediately remove your mouse from the app card
1. [ ] The check should remain in a gray state, and once the add is successful turn to green
1. Now click a green check to remove an app and immediately remove the mouse from the app card
1. [ ] The check should be removed from the card once the removal is successful