### PR TITLE
feat #id 19029 disable import export workspace by default

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -545,7 +545,7 @@ export default class Workspaces extends React.Component {
 							{this.state.focusedWorkspaceComponentList.length === 0 &&
 								"No components."}
 						</div>
-						<div className="workspace-action-buttons">
+						{/* <div className="workspace-action-buttons">
 							<div title={importTooltip} className={importButtonClasses} onMouseDown={this.handleButtonClicks} onClick={allowImport ? this.openFileDialog : Function.prototype}>
 								<i className="workspace-action-button-icon ff-import"></i>
 								<div>Import</div>
@@ -555,7 +555,7 @@ export default class Workspaces extends React.Component {
 								<div>Export</div>
 							</div>
 
-						</div>
+						</div> */}
 					</div>
 				</div>
 				<Checkbox


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19029/details)

**Description of change**
* Hid the import/export workspace buttons

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Ran Finsemble
1. Verified import/export workspace buttons were not present