### PR TITLE
feat #id 19507 Make the basic App Catalog the Default for Finsemble

### DIFF
--- a/src-built-in/components/appCatalog/src/stores/searchStore.js
+++ b/src-built-in/components/appCatalog/src/stores/searchStore.js
@@ -23,7 +23,7 @@ var Actions = {
 	listChange(err, data) {
 		if (!data.value) {
 			values.list = [];
-			finWindow.isShowing(function (value) { })
+			finsembleWindow.isShowing(function (value) { })
 		} else {
 			values.list = data.value;
 		}
@@ -39,7 +39,7 @@ var Actions = {
 	},
 	listItemClick(provider, item, action) {
 		FSBL.Clients.SearchClient.invokeItemAction(provider, item, action)
-		finWindow.hide();
+		finsembleWindow.hide();
 		menuStore.setValue({ field: "list", value: [] })
 	},
 	actionPress(err, msg) {
@@ -68,14 +68,14 @@ function createStore(done) {
 	let defaultData = {
 		inFocus: false,
 		list: [],
-		owner: finWindow.name
+		owner: finsembleWindow.name
 	};
 
-	finWindow.addEventListener("reloaded", function () {
+	finsembleWindow.addEventListener("reloaded", function () {
 		menuStore.removeListener({ field: "list" }, Actions.listChange);
 	})
 
-	FSBL.Clients.DistributedStoreClient.createStore({ store: "AppCatalog-Store" + finWindow.name, values: defaultData, global: false },
+	FSBL.Clients.DistributedStoreClient.createStore({ store: "AppCatalog-Store" + finsembleWindow.name, values: defaultData, global: false },
 		function (err, store) {
 			menuStore = store;
 			FSBL.Clients.SearchClient.search({ text: "", filter: { resultType: "application" } }, function (err, response) {

--- a/src-built-in/components/toolbar/config.json
+++ b/src-built-in/components/toolbar/config.json
@@ -47,7 +47,7 @@
         "id": "app-launcher",
         "comment": "Change menuType to 'My Apps' for a preview of the finsemble app catalog!",
         "fontIcon": "ff-chevron-down",
-        "menuType": "My Apps"
+        "menuType": "App Launcher"
     },
     {
         "align": "left",


### PR DESCRIPTION
feat: #id 19507

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19507/details)

**Description of change**
* Set default menuType to "App Launcher" in toolbar config
* Fix bug with searchStore where finWindow is undefined

**Description of testing**
1. Checkout this branch and run `npm run dev`
1. Navigate to toolbar > Apps

- [ ] Make sure you see the old / basic apps menu