### PR TITLE
fix: #id 19504 change app catalog user facing messages

### DIFF
--- a/src-built-in/components/appCatalog2/src/components/Toast.jsx
+++ b/src-built-in/components/appCatalog2/src/components/Toast.jsx
@@ -15,11 +15,11 @@ const Toast = props => {
 
 	switch (props.installationActionTaken) {
 		case "add":
-			messageContent = "Added to My Apps";
+			messageContent = "Application Added";
 			classes += " success";
 			break;
 		case "remove":
-			messageContent = "Removed from My Apps";
+			messageContent = "Application Removed";
 			classes += " error";
 			break;
 		default:


### PR DESCRIPTION
fix: #id 19504

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19504/details/)

**Description of change**
* Change the user facing messages when the user adds or removes an app from app catalog

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Launch finsemble with app catalog configured: https://app.getguru.com/card/i8gLqdpT/Setting-Up-App-Catalog?q=app%20catalog
2. Add or remove an app from the showcase, verify the messages changed to the one described in the card