### PR TITLE
[16680]  Fix "Add to Favorites" menu item closes/flickers without user input

### DIFF
--- a/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/myApps/src/components/AppActionsMenu.jsx
@@ -32,16 +32,23 @@ export default class AppActionsMenu extends React.Component {
 		this.setMenuRef = this.setMenuRef.bind(this);
 		this.deleteApp = this.deleteApp.bind(this);
 		this.handleClickOutside = this.handleClickOutside.bind(this);
+		this.handleWindowBlurred = this.handleWindowBlurred.bind(this);
+
 	}
 
 	componentDidMount() {
 		document.addEventListener("mousedown", this.handleClickOutside);
-		finsembleWindow.addEventListener("blurred", this.handleClickOutside);
+		// Mody on 12/12/19
+		// window.blur seems to work much better than finsembleWindow's
+		// blurred event. The first, is only fired when you actually click
+		// away from the window, while finsembleWindow's blurred fires even 
+		// when you click inside the window, causing possible race conditions.
+		window.addEventListener("blur", this.handleWindowBlurred);
 	}
 
 	componentWillUnmount() {
 		document.removeEventListener("mousedown", this.handleClickOutside);
-		finsembleWindow.removeEventListener("blurred", this.handleClickOutside);
+		window.removeEventListener("blur", this.handleWindowBlurred);
 	}
 
 	toggleMenu(e) {
@@ -120,6 +127,12 @@ export default class AppActionsMenu extends React.Component {
 				isVisible: false
 			});
 		}
+	}
+
+	handleWindowBlurred() {
+		this.setState({
+			isVisible: false
+		});
 	}
 
 	/**

--- a/src-built-in/components/myApps/src/components/SearchBox.jsx
+++ b/src-built-in/components/myApps/src/components/SearchBox.jsx
@@ -44,10 +44,10 @@ export default class SearchBox extends React.Component {
 		return (
 			<div className="search-box"> 
 				<i className="ff-search" />
-				<input required class="input-box" ref={this.textInput} value={this.state.search}  
+				<input required className="input-box" ref={this.textInput} value={this.state.search}  
 				type="text" placeholder="Search" 
 				onChange={this.onSearch} />
-				<button class="close-icon" onClick={this.clearSearch} type="reset"></button>
+				<button className="close-icon" onClick={this.clearSearch} type="reset"></button>
 			</div>	
 			)
 	}


### PR DESCRIPTION
fix: #id [16680]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/16680/details)

**Description of change**
* Use window's on blur event instead of finsembleWindow's blurred

**Description of testing**
1. Checkout this branch, and edit toolbar's component config.json
1. Set `menuType` to `My Apps`
1. Start finsemble `npm run dev`
1. Click on Apps to open app catalog then click on the 3 vertical dots next to each app to toggle the menu`
1. [ ] Make sure that `Add to favorites` menu item does not hides/blink regardless of how many time you try