### PR TITLE
Add new line and remove duplicate lodash-get entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "hadouken-js-adapter": "1.43.1",
         "lodash.clonedeep": "4.5.0",
         "lodash.debounce": "4.0.8",
-        "lodash.get": "^4.4.2",
         "lodash.throttle": "4.1.1",
         "nocache": "2.0.0"
     },


### PR DESCRIPTION
Fixes the duplicate entry for `lodash-get`, and adds the missing newline at the end of the file.