### PR TITLE
20022 disable tabbing and tiling by default

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -23,8 +23,6 @@
 					"windowService": {
 						"allowSnapping": true,
 						"allowGrouping": true,
-						"allowTabbing": true,
-						"allowTiling": true,
 						"allowAutoArrange": true,
 						"allowMinimize": true
 					}

--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -77,10 +77,10 @@
 			"undockDisbandsEntireGroup": false,
 			"fillHolesOnUndock": true,
 			"tabbing": {
-				"enabled": true
+				"enabled": false
 			},
 			"tiling": {
-				"enabled": true
+				"enabled": false
 			}
 		},
 		"logger": {


### PR DESCRIPTION
fix: #id 20022

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20022/details)

**Description of change**
* set tabbing and tiling to false by default

**Description of testing**
1. Start Finsemble
2. Spawn two Welcome components
- [ ] You can't make tabbing or tiling with them