### PR TITLE
save

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/tab.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/tab.jsx
@@ -38,7 +38,7 @@ export default class Tab extends React.Component {
 	}
 
 	crossedMidline(e, box) {
-		return FSBL.Clients.WindowClient.isPointInBox({ x: e.nativeEvent.screenX, y: e.nativeEvent.screenY }, box);
+		return FSBL.Clients.WindowClient.isPointInBox({ x: e.nativeEvent.clientX, y: e.nativeEvent.clientY }, box);
 	}
 
 	hoverAction(newHoverState) {


### PR DESCRIPTION
fix: #id 19583

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19583/details/)

**Description of change**
* Evidently we were always using the wrong coordinates (screenX and screenY). Using clientX and clientY instead fixed the problem.  Guessing it must have worked before with screenX and screenY only because of a bug in electron 4.  then when the bug was fixed in Electron 7, it broke us.  

**Description of testing**
1. Create stacked window then reorder the tabs and also drop tab back on to itself.  Should all work. 

