### PR TITLE
fix: #id 19920 Fix a bug where components installed via the advanced app launcher did so incorrectly

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -220,7 +220,9 @@ async function addApp(id, cb = Function.prototype) {
 		name: app.title || app.name,
 		url: app.url,
 		type: "component",
-		component: {},
+		component: {
+			type: app.title || app.name
+		},
 		window: {
 			windowType: app.windowType || "WebWindow"
 		},
@@ -309,10 +311,10 @@ function removeApp(id, cb = Function.prototype) {
 					delete folders[key].apps[id];
 				}
 			}
-	
+
 			//Delete the app from the list
 			delete installed[id];
-	
+
 			getStore().setValues([
 				{
 					field: "appDefinitions",

--- a/src-built-in/components/advancedAppLauncher/src/index.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/index.jsx
@@ -62,7 +62,7 @@ class AppLauncher extends React.Component {
 	openAppMarket() {
 		FSBL.Clients.LauncherClient.showWindow(
 			{
-				componentType: "App Catalog"
+				componentType: "Advanced App Catalog"
 			},
 			{
 				monitor: "mine",
@@ -97,11 +97,11 @@ if (window.FSBL && FSBL.addEventListener) {
 	window.addEventListener("FSBLReady", FSBLReady);
 }
 
-function FSBLReady(){
+function FSBLReady() {
 	createStore((store) => {
 		storeActions.initialize(() => {
 			ReactDOM.render(<AppLauncher />,
-			document.getElementById("wrapper"));
+				document.getElementById("wrapper"));
 		});
 	});
 }


### PR DESCRIPTION
fix: #id [19920]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19920/details)

**Description of change**
* The code undergirding pins needs work. This bug came down to some nuance in how components are registered and how their configs are updated. Essentially the Process Monitor was registering as a 'nonConfiguredComponent'; and that's where its pin was going (the 2nd time...the first time, the system couldn't distinguish between this one and the one installed initially). 

So when you'd try to remove the 'process monitor' pin, noting would happen. Only the 'nonConfiguredComponent' would be pinned.

This PR changes component registration so that apps registered via the advanced app catalog register with a component type and do not end up saved as 'nonConfiguredComponent'.

**Description of testing**
1. Modify `configs/application/configs.json` => line 155. Change it to the URL on line 154.
2. Open up the FDC3 AppD server and run `npm run start`
3. Change `src-built-in/components/toolbar/config.json` line 50 to 'Advanced App Launcher'.
4. Go into `src-built-in\components\advancedAppLauncher\src\components\LeftNavBottomLinks.jsx` and remove the comment on line 8 to enable app catalog.
5. Start finsemble, add Process monitor from the advancedapp catalog.
6. In the advanced app launcher, add it to favorites by dragging to the folder or via the 3 dots on the right.
7. Click the 3 dots for 'process monitor' (the one with tags), and click 'delete app'.
8. Go back to advanced app launcher and add process monitor again.
9. Add it to favorites again.
10. Delete app as in step 7. Observe the pin being removed from the toolbar.