### PR TITLE
19915 Fix clean search field issue

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/SearchBar.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/SearchBar.jsx
@@ -53,7 +53,7 @@ class SearchBar extends Component {
 		if (searchTerms !== "") {
 			this.props.search(searchTerms);
 		} else {
-			storeActions.refreshTagSearch();
+			this.goHome();
 		}
 	}
 
@@ -123,7 +123,7 @@ class SearchBar extends Component {
 					<div className="search-input-container">
 						<i className='ff-search'></i>
 						<input className='search-input' required ref={this.textInput}placeholder="Search" type="text" value={this.state.searchValue} onChange={this.changeSearch} />
-						<button class="close-icon" onClick={this.clearSearch} type="reset"></button>
+						<button class="close-icon" onClick={this.goHome} type="reset"></button>
 					</div>
 					<TagsMenu active={activeTags} list={this.props.tags} onItemClick={this.selectTag} label={"Tags"} align='right' />
 				</div>

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -141,7 +141,7 @@ function _refreshTags() {
 	let { activeTags, apps } = data;
 
 	let newApps = apps.filter((app) => {
-		for (let i = o; i < activeTags.length; i++) {
+		for (let i = 0; i < activeTags.length; i++) {
 			const tag = activeTags[i].trim();
 			if (app.tags.includes(tag)) {
 				return true;


### PR DESCRIPTION
fix: #id [19915]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19915/details)

**Description of change**
* Set proper callbacks for the search field clean event

**Description of testing**
Setup https://app.getguru.com/card/i8gLqdpT/Setting-Up-Advanced-App-Catalog
1) Open Advanced App Catalog
2) Type Notepad in the Search field
3) Remove Notepad from the Search field
- [ ] App Catalog page is shown
4) Type Notepad in the Search field
5) Click **x** to clean the search field
- [ ] App Catalog page is shown
