### PR TITLE
[19852] Fix: window control lost when dropping tabs

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -125,6 +125,9 @@ export default class TabRegion extends React.Component {
 	 * @memberof windowTitleBar
 	 */
     stopDrag(e) {
+        // We don't want onDropHandler() in windowTitleBarComponent.jsx
+        // to handle this drop event, so we call event.stopPropagation().
+        e.stopPropagation();
         FSBL.Clients.Logger.system.debug("Tab stopDrag.");
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,

--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -181,6 +181,14 @@ class WindowTitleBar extends React.Component {
 	}
 
 	/**
+	 * Called whenever a tab is dropped on a non tab area.
+	 * It won't be called when dropped on a tab that handles handle the event.
+	 */
+	onDropHandler() {
+		FSBL.Clients.WindowClient.cancelTilingOrTabbing({});
+	}
+
+	/**
 	 * The dragger is an absolutely positioned element that is superimposed on the actual area that we'd like to drag.
 	 * This is necessary due to a bug in Chromium. Effectively, we need the dragger to change its left position and width
 	 * to match the intended drag area. These dimensions can change whenever the header is re-rendered (for instance when
@@ -378,7 +386,7 @@ class WindowTitleBar extends React.Component {
 		}
 		//See this.allowDragOnCenterRegion for more explanation.
 		return (
-			<div className={headerClasses}>
+			<div className={headerClasses} onDrop={this.onDropHandler.bind(this)}>
 				{/* Only render the left section if something is inside of it. The left section has a right-border that we don't want showing willy-nilly. */}
 				{RENDER_LEFT_SECTION &&
 					<div className="fsbl-header-left">


### PR DESCRIPTION
fix: #id [19852]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19852/details)

**Description of change**
* Created an drop event handler for non tab areas in titlebar.
* Stop event propagation when tab is dropped on another tab.

**Description of testing**
1. Create 2-3 welcome components
1. Tab all components
1. Drag any tab and drop it on an empty area in title bar
1. [x] Shouldn't loose window control
1. [x] Should see a blue scrim when hovering on windows

See the following card to see what the bug looks like
https://chartiq.kanbanize.com/ctrl_board/18/cards/14562/details/