### PR TITLE
chore: update max supported node version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,7 +24,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 	const FEA_PATH_EXISTS = fs.existsSync(FEA_PATH);
 	const FEA = FEA_PATH_EXISTS ? require("@chartiq/finsemble-electron-adapter/exports") : undefined;
 	const FEAPackager = FEA ? FEA.packager : undefined;
-	const MAX_NODE_VERSION = '10.15.3';
+	const MAX_NODE_VERSION = '12.13.1';
 
 	// local
 	const extensions = fs.existsSync("./gulpfile-extensions.js") ? require("./gulpfile-extensions.js") : undefined;


### PR DESCRIPTION
We support 12.13.1, this updates the max version to reflect this.