### PR TITLE
20449 Remove reference to dashboards

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/Content.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/Content.jsx
@@ -132,7 +132,7 @@ export default class Content extends React.Component {
 	getNoResultsMessage() {
 		const messages = {
 			search: ["No results found. Please try again."],
-			Favorites: ["There’s nothing here!", <br />, "Add apps and dashboards to Favorites to view them here."],
+			Favorites: ["There’s nothing here!", <br />, "Add apps to Favorites to view them here."],
 			//Dashboards: ['There’s nothing here!', <br />, 'Press “New Dashboard” to construct an Dashboard.'],
 			default: ["There’s nothing here!", <br />, "Add apps to folders to view them here."]
 		};


### PR DESCRIPTION
fix: #id [20449]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20449/details)

**Removed reference to dashboards in Advanced App Launcher**
* Changed empty favorites string

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Open Advanced App Launcher
1. Open an empty favorites folder
1. Verify that the text says: "There’s nothing here! Add apps to Favorites to view them here."