### PR TITLE
Add 'accessibleLinker' to component state for proper initialization

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
@@ -17,7 +17,8 @@ export default class LinkerGroups extends React.Component {
         windowTitleBarStore = getStore();
         this.bindCorrectContext();
         this.state = {
-            channels: FSBL.Clients.LinkerClient.getState().channels
+            channels: FSBL.Clients.LinkerClient.getState().channels,
+            accessibleLinker: false
         };
     }
     /**
@@ -41,8 +42,12 @@ export default class LinkerGroups extends React.Component {
                 console.err("Error getting accessibleLinker value", err);
             }
 
+            console.log('got accessibleLinker value: ', value);
+
             // Default value for accessibleLinker is true.
-            accessibleLinker = (value && typeof value === "boolean") ? value : true;
+            this.setState({
+                accessibleLinker: value && typeof value === "boolean" ? value : true
+            });
         });
         windowTitleBarStore.addListener({ field: "Linker.channels" }, this.onChannelChange);
     }
@@ -74,7 +79,6 @@ export default class LinkerGroups extends React.Component {
      * @memberof LinkerGroups
      */
     onStoreChanged(newState) {
-        //console.log("store changed ", newState);
         this.setState(newState);
     }
 
@@ -93,7 +97,8 @@ export default class LinkerGroups extends React.Component {
      */
     render() {
         let self = this;
-		const getLabel = (channel, accessibleLinker) => {
+        const { accessibleLinker } = this.state;
+		const getLabel = (channel) => {
 			if (!accessibleLinker) {
                 return null;
             } else if (channel.label) {
@@ -112,9 +117,9 @@ export default class LinkerGroups extends React.Component {
          * Iterate through the channels that the window belongs to, render a colored bar to denote channel membership.
          */
         let channels = self.state.channels.map(function (channel, index) {
-            let classNames = `linker-group${accessibleLinker ? " linker-group-accessible" : ""} linker-${channel.label}`;
+            let classNames = `linker-group${accessibleLinker ? ` linker-group-accessible linker-${channel.label}` : ""}`;
             return (<div key={channel.name} className={classNames} title={"Channel " + getChannelLabelFromIndex(channel.name, FSBL.Clients.LinkerClient.getAllChannels())} style={{ background: channel.color }} onMouseUp={function (e) { self.onClick(e, channel.name) }}>
-                {getLabel(channel, accessibleLinker)}
+                {getLabel(channel)}
             </div>);
         });
         return (<div className="linker-groups">

--- a/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/left/LinkerGroups.jsx
@@ -42,8 +42,6 @@ export default class LinkerGroups extends React.Component {
                 console.err("Error getting accessibleLinker value", err);
             }
 
-            console.log('got accessibleLinker value: ', value);
-
             // Default value for accessibleLinker is true.
             this.setState({
                 accessibleLinker: value && typeof value === "boolean" ? value : true


### PR DESCRIPTION
fix: #id [20467]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20467/details)

**Description of change**
* Added 'accessibleLinker' to component state for proper initialization; moved it out of global file state

**Description of testing**
1. Add two components to workspace and link them to a channel
1. Reload the saved workspace
1. [ ] windowTitleBar of reloaded windows should have properly styled linker pill (little rounded corner square with a number inside of it)