### PR TITLE
20480 Prevent duplicate tags in Adv App Catalog

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -83,7 +83,7 @@ function _addActiveTag(tag) {
 
 	let { apps, activeTags } = data;
 
-	activeTags.push(tag);
+	if (!activeTags.includes(tag)) {activeTags.push(tag);}
 
 	let newApps = apps.filter((app) => {
 		for (let i = 0; i < activeTags.length; i++) {


### PR DESCRIPTION
fix: #id [20480]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20480/details)

**Prevent duplicate tags in Advanced App Catalog**
* Added a check so we don't get duplicate values in tags

**Description of testing**

1. Set up advanced app catalog: https://app.getguru.com/card/i8gLqdpT/Setting-Up-Advanced-App-Catalog?q=app%20catalog
1. In the Catalog, choose a tag. (App) In the now filtered carousel, click the same tag on the card.
1. App is only shown as a selected tag once.