### PR TITLE
save

### DIFF
--- a/src-built-in/components/linker/src/linker.jsx
+++ b/src-built-in/components/linker/src/linker.jsx
@@ -33,23 +33,35 @@ class Linker extends React.Component {
 				});
 		}
 	}
+
 	/**
-	 * Event handler when the user clicks on a colored rectangle, indicating that they want the attached window to join the channel.
+	 * Event handler when the user clicks on a colored rectangle, indicating channel state should be toggled
 	 *
-	 * @param {any} channel
-	 * @param {any} active
-	 * @returns
+	 * @param {any} channel the linker channel
+	 * @param {any} active true if channel was already active
 	 * @memberof Linker
 	 */
 	channelClicked(channel, active) {
 		var attachedWindowIdentifier = LinkerStore.getAttachedWindowIdentifier();
+
+
 		FSBL.FinsembleWindow.getInstance({ name: attachedWindowIdentifier.windowName }, (err, attachedWindow) => {
 			if (attachedWindow) attachedWindow.focus();
 		});
 
-		if (!active) return LinkerActions.linkToChannel(channel.name);
-		LinkerActions.unlinkFromChannel(channel.name);
+		if (!active) {
+			LinkerActions.linkToChannel(channel.name);
+		} else {
+			LinkerActions.unlinkFromChannel(channel.name);
+		}
+
+		// Immediately hide linker window when channel clicked.
+		// Note: the focus above on the attached window will typically result in a blur event to the linker window that will also hide; howevever, that blur
+		// event is not received for native windows.
+		finsembleWindow.hide();
+
 	}
+
 	/**
 	 * Hides window on blur.
 	 *


### PR DESCRIPTION
fix: #id 20545

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20545/details/)

**Description of change**
Always hide linker window immediately when a linker channel selection changes.  Preciously this happen for Finsemble components but not native components. 

**Description of testing**
1. Spawn a WPF component. 
2. Select the linker icon on the WPF component.
3. Check/Uncheck a linker channel -- when this is done the linker window should immediately close.  