### PR TITLE
Added Static Analysis

### DIFF
--- a/azure-staticanalysis.yml
+++ b/azure-staticanalysis.yml
@@ -1,0 +1,31 @@
+trigger:
+  - master
+  - pr
+  
+pool:
+  vmImage: 'VS2017-Win2016'
+  
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '10.15.3'
+  displayName: 'Install Node.js'
+
+- task: Npm@1
+  inputs:
+    command: 'install'
+    workingDir: '.'
+    customEndpoint: 'ciq'
+
+- task: SonarQubePrepare@4
+  inputs:
+    SonarQube: 'SonarQube Finsemble-Seed'
+    scannerMode: 'CLI'
+    configMode: 'manual'
+    cliProjectKey: 'Finsemble-Seed'
+    cliProjectName: 'Finsemble-Seed'
+    cliSources: '.'
+- task: SonarQubeAnalyze@4
+- task: SonarQubePublish@4
+  inputs:
+    pollingTimeoutSec: '300'


### PR DESCRIPTION
Now ready to merge in!

Static Analysis is run on azure in parallel to the build process. If the Static Analysis fails then the build process will continue. A separate failure message is shown in #finsemble-builds and in the checks section for a PR. You can see that in this PR in fact.

What this PR should do:

- Add the static analysis testing to azure devops in the form of a new yaml file
- Not fail the build if the static analysis fails