### PR TITLE
20921 app catalog back button

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/app.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/app.jsx
@@ -140,8 +140,9 @@ export default class AppMarket extends React.Component {
 	}
 
 	/**
-	 * The store has pushed an update to the filtered tags list. This means a user has begun searching or added tags to the filter list
-	 * 
+	 * Force an update. Used to update from store listeners.
+	 *
+	 * @memberof AppMarket
 	 */
 	update() {
 		this.forceUpdate();
@@ -169,9 +170,9 @@ export default class AppMarket extends React.Component {
 	}
 
 	/**
+	 * Returns the activeApp from the Store
 	 *
-	 *
-	 * @returns
+	 * @returns {string} activeApp
 	 * @memberof AppMarket
 	 */
 	getActiveApp() {
@@ -179,9 +180,9 @@ export default class AppMarket extends React.Component {
 	}
 
 	/**
+	 * Checks if we have an activeApp defined
 	 *
-	 *
-	 * @returns
+	 * @returns {boolean}
 	 * @memberof AppMarket
 	 */
 	isActiveApp() {
@@ -189,9 +190,9 @@ export default class AppMarket extends React.Component {
 	}
 
 	/**
+	 * Returns the active tags from the store
 	 *
-	 *
-	 * @returns
+	 * @returns {array} activeTags
 	 * @memberof AppMarket
 	 */
 	getActiveTags() {
@@ -199,9 +200,9 @@ export default class AppMarket extends React.Component {
 	}
 
 	/**
+	 * Returns the filtered list of apps from search
 	 *
-	 *
-	 * @returns
+	 * @returns {object} filteredApps
 	 * @memberof AppMarket
 	 */
 	getFilteredApps() {

--- a/src-built-in/components/advancedAppCatalog/src/app.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/app.jsx
@@ -290,7 +290,7 @@ export default class AppMarket extends React.Component {
 		});
 	}
 	getPageContents() {
-		let filteredApps = this.getFilteredApps();
+		const filteredApps = this.getFilteredApps();
 		let activeTags = this.getActiveTags();
 		let activePage = this.determineActivePage();
 		let apps = this.compileAddedInfo((filteredApps.length > 0));

--- a/src-built-in/components/advancedAppCatalog/src/app.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/app.jsx
@@ -291,7 +291,7 @@ export default class AppMarket extends React.Component {
 	}
 	getPageContents() {
 		const filteredApps = this.getFilteredApps();
-		let activeTags = this.getActiveTags();
+		const activeTags = this.getActiveTags();
 		let activePage = this.determineActivePage();
 		let apps = this.compileAddedInfo((filteredApps.length > 0));
 		//Force default case if activepage isn't search and apps.length is 0

--- a/src-built-in/components/advancedAppCatalog/src/components/SearchBar.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/SearchBar.jsx
@@ -26,7 +26,8 @@ class SearchBar extends Component {
 		super(props);
 		this.textInput = React.createRef();
 		this.state = {
-			tagSelectorOpen: false
+			tagSelectorOpen: false,
+			searchText: ""
 		};
 		this.bindCorrectContext();
 	}
@@ -45,6 +46,7 @@ class SearchBar extends Component {
 	 */
 	changeSearch(e) {
 		const { value : searchTerms } = e.target;
+		this.setState({searchText: searchTerms});
 		this.props.search(searchTerms);
 	}
 
@@ -84,6 +86,7 @@ class SearchBar extends Component {
 	 * Clears search because 'back' button was clicked
 	 */
 	goHome() {
+		this.setState({searchText: ""});
 		this.props.goHome();
 	}
 
@@ -111,13 +114,13 @@ class SearchBar extends Component {
 						</div> : null}
 					<div className="search-input-container">
 						<i className='ff-search'></i>
-						<input className='search-input' required ref={this.textInput}placeholder="Search" type="text" value={this.props.searchText} onChange={this.changeSearch} />
+						<input className='search-input' required ref={this.textInput} placeholder="Search" type="text" value={this.state.searchText} onChange={this.changeSearch} />
 						<button class="close-icon" onClick={this.goHome} type="reset"></button>
 					</div>
 					<TagsMenu active={activeTags} list={this.props.tags} onItemClick={this.selectTag} label={"Tags"} align='right' />
 				</div>
 				<div className='label-bar'>
-					{this.props.activeTags.map((tag, i) => {
+					{activeTags.map((tag, i) => {
 						return (
 							<Tag key={tag} name={tag} removeTag={this.removeTag} />
 						);

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -329,6 +329,9 @@ function openApp(id) {
 	}
 }
 
+/**
+ * Clear the activeApp in store
+ */
 function clearApp() {
 	getStore().setValue({
 		field: "activeApp",
@@ -336,6 +339,11 @@ function clearApp() {
 	});
 }
 
+/**
+ * Return activeApp from store
+ *
+ * @returns {string} activeApp
+ */
 function getActiveApp() {
 	return data.activeApp;
 }

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -25,6 +25,7 @@ export default {
 	clearApp,
 	getInstalledApps,
 	getActiveApp,
+	setActiveApp,
 	filterApps,
 	setSearchValue,
 	setForceSearch,
@@ -337,6 +338,18 @@ function clearApp() {
 
 function getActiveApp() {
 	return data.activeApp;
+}
+
+/**
+ * Set the activeApp param in store
+ *
+ * @param {*} app
+ */
+function setActiveApp(app) {
+	getStore().setValue({
+		field: "activeApp",
+		value: app
+	});
 }
 
 /**


### PR DESCRIPTION
fix: #id [20921]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20921/details)

**Cleaned up state/store logic for App Catalog**
We had several listeners that were copying data to and from state. When we moved the state data into store for combinatory searching, we (I) introduced some timing issues with those listeners.

* ActiveApp, filteredApps, activeTags... Are all moved to central store entirely. We should not be relying on copies of these in state.
* Listeners have been cleaned up to prevent the exchange of local state to store. 
* Helpers have been added to get store values for UI instead of relying on state data.

**Description of testing**

1. Build this branch with Advanced App catalog: https://app.getguru.com/card/i8gLqdpT/Setting-Up-Advanced-App-Catalog
1. Verify that you can search via any combination of tags and text.
1. Verify that when no tags are selected and the search field is empty, AAC returns to the home page.
1. Verify that the "Back" button will return you to the home page under all search conditions
1. Verify that you can click on a component title and bring up the showcase.
1. Verify that the "Back" button will take you back to the homepage from the showcase.