### PR TITLE
20921 set forceSearch earlier

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/app.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/app.jsx
@@ -256,9 +256,9 @@ export default class AppMarket extends React.Component {
 		let app = storeActions.getActiveApp();
 		
 		if (app !== null) {
+			storeActions.setForceSearch(false);
 			storeActions.clearTags();
 			storeActions.clearFilteredApps();
-			storeActions.setForceSearch(false);
 		}
 
 		this.forceUpdate();


### PR DESCRIPTION
fix: #id [20921]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/20921/details)

**Set forceSearch earlier**
* In some cases, searching and then clicking on an app card would not open the showcase. Moving the forceSearch to an earlier point in the code to help.

**Description of testing**

1. Open AAC
1. Search using text only
1. Click on an app card
1. Showcase opens.