### PR TITLE
21061 add defaults to zoom preload

### DIFF
--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -10,8 +10,6 @@
 	- Zoom level being preserved in window state/workspaces
 	- Default zoom level config with-in the component configuration at:
 	  `foreign.components.['Window Manager'].zoomDefault`
-
-	N.B. should not be used with OpenFin's window.options.accelerator.zoom option.
 */
 
 // This global will contain our current zoom level
@@ -208,24 +206,21 @@ const getZoomLevelHandler = (err, zoomLevel) => {
 	if (err) {
 		FSBL.Clients.Logger.info("No \"fsbl-zoom\" settings found in component state", err);
 	} else if (zoomLevel != null) {
-		FSBL.Clients.Logger.info(`Retrieved zoomLevel from state: ${zoomLevel}`, err);
+		FSBL.Clients.Logger.info(`Retrieved zoomLevel from state: ${zoomLevel}`);
 		window.fsblZoomLevel = zoomLevel;
 		setZoom(window.fsblZoomLevel);
-		window.settingInitialZoom = false;
 	} else {
 		//check for default configuration for zoom level and apply as needed
 		let defaultLevel = _.get(FSBL.Clients.WindowClient.options.customData, "foreign.components.['Window Manager'].zoomDefault");
 		if (defaultLevel) { 
-			FSBL.Clients.Logger.info(`Retrieved default zoom level from config: ${defaultLevel}`, err);
+			FSBL.Clients.Logger.info(`Retrieved default zoom level from config: ${defaultLevel}`);
 			window.fsblZoomLevel = defaultLevel;
 			setZoom(defaultLevel); 
-			window.settingInitialZoom = false;
 		} else {
-			FSBL.Clients.Logger.info("No default zoom level retrieved from config: ",response.data, err);
-			window.settingInitialZoom = false;
+			FSBL.Clients.Logger.info("No default zoom level retrieved from configuration ");
 		}
-		
 	}
+	window.settingInitialZoom = false;
 };
 
 /**
@@ -253,7 +248,7 @@ const runZoomHandler = () => {
 	// Updates the component with the zoom level from the previous load, if one exists.
 	FSBL.Clients.WindowClient.getComponentState({ field: "fsbl-zoom" }, getZoomLevelHandler);
 
-	window.addEventListener("wheel", handleWheel, false);
+	window.addEventListener("wheel", handleWheel, {capture: false, passive: false});
 };
 
 // TODO, catch and recall scroll position

--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -11,6 +11,7 @@
 	- Default zoom level config with-in the component configuration at:
 	  `foreign.components.['Window Manager'].zoomDefault`
 */
+const _get = require("lodash.get");
 
 // This global will contain our current zoom level
 window.fsblZoomLevel = 1;
@@ -211,7 +212,7 @@ const getZoomLevelHandler = (err, zoomLevel) => {
 		setZoom(window.fsblZoomLevel);
 	} else {
 		//check for default configuration for zoom level and apply as needed
-		let defaultLevel = _.get(FSBL.Clients.WindowClient.options.customData, "foreign.components.['Window Manager'].zoomDefault");
+		let defaultLevel = _get(FSBL.Clients.WindowClient.options.customData, "foreign.components.['Window Manager'].zoomDefault");
 		if (defaultLevel) { 
 			FSBL.Clients.Logger.info(`Retrieved default zoom level from config: ${defaultLevel}`);
 			window.fsblZoomLevel = defaultLevel;

--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -218,7 +218,7 @@ const getZoomLevelHandler = (err, zoomLevel) => {
 					let defaultLevel = _.get(response.data, "foreign.components.['Window Manager'].zoomDefault");
 					if (defaultLevel) { 
 						FSBL.Clients.Logger.info(`Retrieved default zoom level from config: ${defaultLevel}`, err);
-						window.fsblZoomLevel = zoomLevel;
+						window.fsblZoomLevel = defaultLevel;
 						setZoom(defaultLevel); 
 						window.settingInitialZoom = false;
 					} else {


### PR DESCRIPTION
feat: #id [21061]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/48/cards/21061/details)

**Description of change**
* Add support for default zoom config setting at `foreign.components.['Window Manager'].zoomDefault` in the component config

**Description of testing**
1. Edit the Welcome Component config and set `foreign.components.['Window Manager'].zoomDefault = 0.5`
1. Spawn the Welcome component and check that it is zoomed out to 50%
1. change the zoom level and save into a workspace
1. reload the workspace and ensure that the zoom level is preserved in state in preference to default zoom level