### PR TITLE
fix: #id 19998 Add comments to specify what characters are allowed in the installer name

### DIFF
--- a/configs/other/installer.json
+++ b/configs/other/installer.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0",
 	"//outputDirectory": "Path where you would like the executable to be dumped. This is relative to the root of the finsemble-seed",
 	"outputDirectory": "./pkg",
-	"//name": "Name of your application. Will be used for the exe and windows metadata.",
+	"//name": "Name of your application. Will be used for the exe and windows metadata. Only alphabet characters, spaces, dashes(-), periods(.), and underscores(_) are allowed",
 	"name": "xyz",
 	"authors": "ChartIQ",
 	"//certificateFile": "The path to an Authenticode Code Signing Certificate",

--- a/configs/other/installer.json
+++ b/configs/other/installer.json
@@ -4,7 +4,7 @@
 	"version": "1.0.0",
 	"//outputDirectory": "Path where you would like the executable to be dumped. This is relative to the root of the finsemble-seed",
 	"outputDirectory": "./pkg",
-	"//name": "Name of your application. Will be used for the exe and windows metadata. Only alphabet characters, spaces, dashes(-), periods(.), and underscores(_) are allowed",
+	"//name": "Name of your application. Will be used for the exe and windows metadata. Only alphanumeric characters, spaces, dashes(-), periods(.), and underscores(_) are allowed",
 	"name": "xyz",
 	"authors": "ChartIQ",
 	"//certificateFile": "The path to an Authenticode Code Signing Certificate",


### PR DESCRIPTION
fix: #id 19998
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19998/details/)

See https://github.com/ChartIQ/finsemble-electron-adapter/pull/182 for details