### PR TITLE
fix: #id 21548If manifest from appd is an object, use it

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
@@ -13,7 +13,6 @@ const DEFAULT_APP_DESCRIPTION = "Get started by adding this component to Finsemb
  */
 const AppDescription = props => {
 
-	console.log(props);
 	const description = props.description === undefined ? DEFAULT_APP_DESCRIPTION : props.description;
 
 	return (

--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
@@ -10,11 +10,14 @@ import React from "react";
  * @param {string} props.description The app description
  */
 const AppDescription = props => {
+
+	const description = props.description === null ? "Get started by adding this component to Finsemble now!" : props.description;
+
 	return (
 		<div className="app-notes description">
 			<span className="showcase-label">Description</span>
 			<div className="description-content">
-				<div>{props.description || DEFAULT_APP_DESCRIPTION}</div>
+				<div>{description}</div>
 			</div>
 		</div>
 	);

--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppDescription.jsx
@@ -4,6 +4,8 @@
 */
 import React from "react";
 
+const DEFAULT_APP_DESCRIPTION = "Get started by adding this component to Finsemble now!";
+
 /**
  * AppShowcase description section
  * @param {object} props Component props
@@ -11,7 +13,8 @@ import React from "react";
  */
 const AppDescription = props => {
 
-	const description = props.description === null ? "Get started by adding this component to Finsemble now!" : props.description;
+	console.log(props);
+	const description = props.description === undefined ? DEFAULT_APP_DESCRIPTION : props.description;
 
 	return (
 		<div className="app-notes description">

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -178,25 +178,6 @@ async function getTags() {
 }
 
 /**
- * @param {string} data The data to attempt to parse into JSON
- * @param {string} title The name of the app that is being parsed
- * @param {boolean} logError Whether or not to log an error if the parsing fails
- * @private
- */
-function tryToParseJSON(data, title, logError) {
-	let output;
-	try {
-		output = JSON.parse(data);
-	} catch(e) {
-		if (logError) {
-			FSBL.Clients.Logger.system.warn(`Failure encountered parsing manifest for ${title}. Creating a default manifest`);
-		}
-	} finally {
-		return output;
-	}
-} 
-
-/**
  * Function to "install" an app. Adds the id to a list of installed apps
  * @param {string} name The name of the app
  */

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -248,8 +248,8 @@ async function addApp(id, cb = Function.prototype) {
 				//Attempt to parse the url response
 				manifest = await urlRes.json();
 			} catch(e) {
-				FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Creating a default manifest`);
-				manifest = { ...appConfig };
+				FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Unable to add app`);
+				return cb();
 			}
 		} finally {
 			appConfig.manifest = manifest;

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -239,7 +239,7 @@ async function addApp(id, cb = Function.prototype) {
 	try {
 		manifest = JSON.parse(app.manifest);
 	} catch(e) {
-		FSBL.Clients.Logger.warn(`${app.title || app.name} is missing a valid manifest. Creating a default manifest`);
+		FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest. Creating a default manifest`);
 		manifest = { ...appConfig };
 	}
 

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -236,19 +236,18 @@ async function addApp(id, cb = Function.prototype) {
 	}
 
 	let manifest;
+	// Manifest from FDC3 is a string property which can either be a stringified JSON, or a uri which delivers valid JSON.
+	// The catalog will attempt to parse the string as JSON, then fetch from a URL if that fails.
+	// If both paths fail, notify the user that this app can't be added
 	if (app.manifestType.toLowerCase() === "finsemble") {
 		try {
-			//Attempt to parse a string as JSON
 			manifest = JSON.parse(app.manifest);
 		} catch(e) {
 			try {
-				//If parsing fails, assume the manifest is a valid url that will return JSON
 				const urlRes = await fetch(app.manifest, { method: "GET" });
-
-				//Attempt to parse the url response
 				manifest = await urlRes.json();
 			} catch(e) {
-				FSBL.Clients.Logger.system.error(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Unable to add app`);
+				FSBL.Clients.Logger.system.error(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Unable to add app.`);
 				return cb();
 			}
 		} finally {

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -275,6 +275,7 @@ async function addApp(id, cb = Function.prototype) {
 		}
 	} else {
 		FSBL.Clients.Logger.system.warn(`${app.title || app.name} does not appear to be a Finsemble manifest. This app cannot be added to Finsemble.`);
+		return cb();
 	}
 
 	if (app.friendlyName) {

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -239,7 +239,7 @@ async function addApp(id, cb = Function.prototype) {
 	try {
 		manifest = JSON.parse(app.manifest);
 	} catch(e) {
-		FSBL.Clients.Logger.warn(`${app.title} is missing a valid manifest. Creating a default manifest`);
+		FSBL.Clients.Logger.warn(`${app.title || app.name} is missing a valid manifest. Creating a default manifest`);
 		manifest = { ...appConfig };
 	}
 

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -237,6 +237,8 @@ async function addApp(id, cb = Function.prototype) {
 
 	if (typeof app.manifest !== "object") {
 		appConfig.manifest = { ...appConfig };
+	} else {
+		appConfig.manifest = app.manifest;
 	}
 
 	if (app.friendlyName) {

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -235,11 +235,15 @@ async function addApp(id, cb = Function.prototype) {
 		delete appConfig.window.url;
 	}
 
-	if (typeof app.manifest !== "object") {
-		appConfig.manifest = { ...appConfig };
-	} else {
-		appConfig.manifest = app.manifest;
+	let manifest;
+	try {
+		manifest = JSON.parse(app.manifest);
+	} catch(e) {
+		FSBL.Clients.Logger.warn(`${app.title} is missing a valid manifest. Creating a default manifest`);
+		manifest = { ...appConfig };
 	}
+
+	appConfig.manifest = manifest;
 
 	if (app.friendlyName) {
 		appConfig.displayName = app.friendlyName;

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -255,22 +255,26 @@ async function addApp(id, cb = Function.prototype) {
 	}
 
 	let manifest;
-	try {
-		//Attempt to parse a string as JSON
-		manifest = JSON.parse(app.manifest);
-	} catch(e) {
+	if (app.manifestType === "Finsemble") {
 		try {
-			//If parsing fails, assume the manifest is a valid url that will return JSON
-			const urlRes = await fetch(app.manifest, { method: "GET" });
-
-			//Attempt to parse the url response
-			manifest = await urlRes.json();
+			//Attempt to parse a string as JSON
+			manifest = JSON.parse(app.manifest);
 		} catch(e) {
-			FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Creating a default manifest`);
-			manifest = { ...appConfig };
+			try {
+				//If parsing fails, assume the manifest is a valid url that will return JSON
+				const urlRes = await fetch(app.manifest, { method: "GET" });
+
+				//Attempt to parse the url response
+				manifest = await urlRes.json();
+			} catch(e) {
+				FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Creating a default manifest`);
+				manifest = { ...appConfig };
+			}
+		} finally {
+			appConfig.manifest = manifest;
 		}
-	} finally {
-		appConfig.manifest = manifest;
+	} else {
+		FSBL.Clients.Logger.system.warn(`${app.title || app.name} does not appear to be a Finsemble manifest. This app cannot be added to Finsemble.`);
 	}
 
 	if (app.friendlyName) {

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -236,7 +236,7 @@ async function addApp(id, cb = Function.prototype) {
 	}
 
 	let manifest;
-	if (app.manifestType === "Finsemble") {
+	if (app.manifestType.toLowerCase() === "finsemble") {
 		try {
 			//Attempt to parse a string as JSON
 			manifest = JSON.parse(app.manifest);
@@ -248,14 +248,14 @@ async function addApp(id, cb = Function.prototype) {
 				//Attempt to parse the url response
 				manifest = await urlRes.json();
 			} catch(e) {
-				FSBL.Clients.Logger.system.warn(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Unable to add app`);
+				FSBL.Clients.Logger.system.error(`${app.title || app.name} is missing a valid manifest or URI that delivers a valid JSON manifest. Unable to add app`);
 				return cb();
 			}
 		} finally {
 			appConfig.manifest = manifest;
 		}
 	} else {
-		FSBL.Clients.Logger.system.warn(`${app.title || app.name} does not appear to be a Finsemble manifest. This app cannot be added to Finsemble.`);
+		FSBL.Clients.Logger.system.error(`${app.title || app.name} does not appear to be a Finsemble manifest. This app cannot be added to Finsemble.`);
 		return cb();
 	}
 


### PR DESCRIPTION
fix: #id [21548]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/CARD/details)

**Description of change**
* If app.manifest is an object, use it instead of custom manifest when adding an app to the launcher

**Description of testing**
1. Remove welcome component from the components.json.
2. Clear cache
3. Add the following code to the 'manifest' field of the Welcome component in data.json of the appd:
`'window': {
				'url': '$applicationRoot/components/welcome/welcome.html',
				'affinity': 'workspaceComponents',
				'frame': false,
				'resizable': true,
				'autoShow': true,
				'top': 'center',
				'left': 'center',
				'width': 400,
				'height': 432
			},
			'component': {
				'displayName': 'Welcome Component',
				'spawnOnStartup': false,
				'preload': '$applicationRoot/preloads/zoom.js'
			},
			'foreign': {
				'services': {
					'windowService': {
						'allowSnapping': true,
						'canGroup': true,
						'allowAutoArrange': true,
						'allowMinimize': true
					}
				},
				'components': {
					'App Launcher': {
						'launchableByUser': true
					},
					'Window Manager': {
						'showLinker': true,
						'FSBLHeader': true,
						'persistWindowState': true,
						'title': 'Welcome to Finsemble'
					},
					'Toolbar': {
						'iconClass': 'ff-component'
					}
				}
			}`
4. Launch Finsemble with the Advanced App Launcher/Advanced App Catalog configured
5. Add the Welcome Component from the app catalog
6. Zoom preload should work (Ctrl +, Ctrl -)