### PR TITLE
21021 Finsemble CLI version update to 3.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "dependencies": {
         "@chartiq/finsemble": "4.0.*",
-        "@chartiq/finsemble-cli": "3.3.1",
+        "@chartiq/finsemble-cli": "3.13.0",
         "@chartiq/finsemble-react-controls": "4.0.*",
         "async": "2.6.2",
         "babel-minify-webpack-plugin": "0.3.1",


### PR DESCRIPTION
feat: #id [21021]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/21021/details)

**Description of change**
* Finsemle CLI dependency version updated to the latest 3.13.0

**Description of testing**
n/a