### PR TITLE
21743 Hero Component redo

### DIFF
--- a/src-built-in/components/advancedAppCatalog/appCatalog.css
+++ b/src-built-in/components/advancedAppCatalog/appCatalog.css
@@ -62,8 +62,20 @@
 	align-items: center;
 }
 
+.hero-wrapper {
+	width: 530px;
+	margin: 0px 5px;
+	padding: 5px 0px;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	cursor: pointer;
+	box-shadow: 1px 2px 4px 0px rgba(0, 0, 0, 0.50);
+}
+
 .hero_selected_content {
-	width: 488px;
+	width: 50%;
 	height: 174px;
 	border: solid 1px var(--catalog-hero-border-color);
 	background-color: var(--catalog-hero-background-color);
@@ -73,7 +85,13 @@
 	display: flex;
 	flex-direction: column;
 	justify-content: flex-start;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.25);
+}
+
+.selected-content-info {
+	width: 67%;
+	display: flex;
+	flex-direction: column;
+	margin: 15px;
 }
 
 .selected-content-title {
@@ -83,27 +101,19 @@
 	color: var(--catalog-font-color);
 	margin-bottom: 10px;
 	padding: 4px;
-	background-color: rgba(0, 0, 0, 0.75);
 	border-radius: 4px;
 }
 
 .selected-content-message {
-	width: 95%;
-	height: 130px;
+	height: 80px;
 	font-size: 12px;
 	font-weight: var(--font-weight);
 	color: var(--catalog-font-color);
-	text-overflow: clip;
+	padding: 4px 10px 4px 4px;
 	overflow: hidden;
-	white-space: normal;
-	align-self: center;
-}
-
-.selected-content-message-wrapper {
-	background-color: rgba(0, 0, 0, 0.75);
-	padding: 4px;
-	border-radius: 4px;
-	width: fit-content;
+	display: -webkit-box;
+	-webkit-line-clamp: 5;
+	-webkit-box-orient: vertical;
 }
 
 .paginator {
@@ -167,7 +177,7 @@
 	justify-content: flex-start;
 	width: 169px;
 	height: 89px;
-	box-shadow: 1px 2px 4px 0 rgba(0, 0, 0, 0.25);
+	box-shadow: 1px 2px 4px 0px rgba(0, 0, 0, 0.25);
 	background-color: var(--catalog-card-background-color);
 	user-select:none;
 	cursor: pointer;

--- a/src-built-in/components/advancedAppCatalog/src/components/Hero.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Hero.jsx
@@ -38,7 +38,7 @@ export default class Hero extends Component {
 		} else {
 			switch (action) {
 				case "page_down":
-					newActive = (newActive - 1 < 0) ? cards.length-1 : newActive - 1;
+					newActive = (newActive - 1 < 0) ? cards.length - 1 : newActive - 1;
 					break;
 				case "page_up":
 					newActive = (newActive + 1 > cards.length - 1) ? 0 : newActive + 1;
@@ -67,25 +67,28 @@ export default class Hero extends Component {
 		let imageUrl = cards[active].images ? cards[active].images[0].url : "../assets/placeholder.svg";
 
 		let bgImageStyle = {
-			background: "url(" + imageUrl + ") center center / 100% no-repeat scroll"
+			background: "no-repeat left center/contain url(" + imageUrl + ")"
 		};
 
 		return (
 			<div>
 				<div className='hero-main'>
 					<i className='ff-adp-chevron-left' onClick={this.changePage.bind(this, 'page_down')} />
-					<div className='hero_selected_content' onClick={this.openApp} style={bgImageStyle}>
-						<div className='selected-content-title'>
-							<span>{contentTitle}</span>
+					<div className="hero-wrapper" onClick={this.openApp}> 
+						<div className="selected-content-info">
+							<div className='selected-content-title'>
+								{contentTitle}
+							</div>
+							<div className='selected-content-message'>
+								{contentMsg}
+							</div>
 						</div>
-						<div className='selected-content-message'>
-							<div className='selected-content-message-wrapper'>{contentMsg}</div>
-						</div>
+						<div className='hero_selected_content' style={bgImageStyle}></div>
 					</div>
 					<i className='ff-adp-chevron-right' onClick={this.changePage.bind(this, 'page_up')} />
 				</div>
 				<br />
-				{cards.length >= 2 && cards.length <= 10 && 
+				{cards.length >= 2 && cards.length <= 10 &&
 					<div className="paginator">
 						{cards.map((card, i) => {
 							let classes = 'pagination-oval';
@@ -94,7 +97,7 @@ export default class Hero extends Component {
 						})}
 					</div>
 				}
- 			</div>
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id [21743]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/21743/details)

**Description of change**
* In the Advanced App Catalog, the hero component has been restructured so the text is no longer lying on top of the image.
* The image is now scaled and in full view. 
* App descriptions longer than 5 lines get truncated.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Enable the Advanced App Catalog, [help here](https://github.com/ChartIQ/finsemble-manual-testing).
1. Open the Advanced App Catalog.
1. Ensure that the text in the hero component sits to the left of the image.
1. Ensure the image in the hero component is scaled and not cut off.