### PR TITLE
toggle import workspace functionality with single const declaration

### DIFF
--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -435,7 +435,8 @@ export default class Workspaces extends React.Component {
 		});
 	}
 	render() {
-		let deleteButtonClasses = "individual-workspace-action delete-workspace",
+			const enableWorkspaceImport = false;
+			let deleteButtonClasses = "individual-workspace-action delete-workspace",
 			exportButtonClasses = "action-button workspace-action-button",
 			renameButtonClasses = "individual-workspace-action",
 			addButtonClasses = "positive-action-button action-button workspace-action-button",
@@ -545,7 +546,7 @@ export default class Workspaces extends React.Component {
 							{this.state.focusedWorkspaceComponentList.length === 0 &&
 								"No components."}
 						</div>
-						{/* <div className="workspace-action-buttons">
+						{enableWorkspaceImport && <div className="workspace-action-buttons">
 							<div title={importTooltip} className={importButtonClasses} onMouseDown={this.handleButtonClicks} onClick={allowImport ? this.openFileDialog : Function.prototype}>
 								<i className="workspace-action-button-icon ff-import"></i>
 								<div>Import</div>
@@ -555,7 +556,7 @@ export default class Workspaces extends React.Component {
 								<div>Export</div>
 							</div>
 
-						</div> */}
+						</div>}
 					</div>
 				</div>
 				<Checkbox


### PR DESCRIPTION
fix|feat|chore|docs|refactor|style|test: #id [CARD]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/CARD/details)

**Description of change**
* removed commented-out code relating to importing workspaces
* added boolean const `enableWorkspaceImport` to toggle feature on/off

**Description of testing**
1. launch seed
1. to go toolbar > preferences > workspaces and verify workspace imports is turned off
1. in line 438 change to `const enableWorkspaceImport = true;`
1. verify workspace import functionality