### PR TITLE
Window titlebar should not register with docking, since the window re…

### DIFF
--- a/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
+++ b/src-built-in/components/windowTitleBar/src/windowTitleBarComponent.jsx
@@ -454,8 +454,6 @@ function init () {
 		HeaderActions = storeExports.Actions;
 		windowTitleBarStore = storeExports.getStore();
 		ReactDOM.render(<WindowTitleBar />, FSBLHeader);
-		// Register with docking manager
-		FSBL.Clients.WindowClient.registerWithDockingManager();
 	});
 }
 


### PR DESCRIPTION
fix: #id [22315]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22315/details)

**Description of change**
* Window title bar should not register with docking since the window registers itself with the windowClient, removed the call to register the titlebar with empty options

**Description of testing**
1. Disable snapping in a component's config
1. [ ] Ensure snapping actually disabled