### PR TITLE
19152 Add types to seed

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,11 +5,13 @@
 		"noImplicitAny": true,
 		"removeComments": true,
 		"preserveConstEnums": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"allowJs": true
 	},
 	"include": [
 		"src/**/*",
-		"src-built-in/**/*"
+		"src-built-in/**/*",
+		"./finsemble/types/**/*"
 	],
 	"exclude": [
 		"node_modules",


### PR DESCRIPTION
feat: #id [19152]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/19152/details)

**Description of change**
- Adds type declaration files to the seed.
- Modifies the tsconfig.json to work correctly.

Ideally, we shouldn't need to do this - VS Code/Typescript should infer the types from the "types" prop of Finsemble's package.json. However, I could not get that to work after several days of trying.

**Description of testing**

- Build and launch finsemble
- Launch one of each: stack of group welcome components, notepad, welcome component.
- Reload the workspace.