### PR TITLE
feat: #id 22723 wrap appCatalog

### DIFF
--- a/build/webpack/defaultWebpackConfig.js
+++ b/build/webpack/defaultWebpackConfig.js
@@ -138,7 +138,8 @@ module.exports = class WebpackDefaults {
 					'react-dom': path.resolve('./node_modules/react-dom'),
 					'@babel/runtime': path.resolve('./node_modules/@babel/runtime'),
 					'@chartiq/finsemble-react-controls': path.resolve('./node_modules/@chartiq/finsemble-react-controls'),
-					'async': path.resolve('./node_modules/async')
+					'async': path.resolve('./node_modules/async'),
+					'lodash.debounce': path.resolve('./node_modules/lodash.debounce'),
 				},
 				extensions: ['.tsx', '.ts', '.js', '.jsx', '.json', 'scss', 'html'],
 				modules: [

--- a/src-built-in/components/appCatalog/src/app.jsx
+++ b/src-built-in/components/appCatalog/src/app.jsx
@@ -10,7 +10,7 @@ import "../../../../assets/css/font-finance.css";
 import "../../../../assets/css/finsemble.css";
 import "../appCatalog.css";
 import "../../complexMenu/menu.css";
-import { AppCatalog } from "@chartiq/finsemble-ui/lib/components/appCatalog/appCatalog";
+import { AppCatalog } from "@chartiq/finsemble-ui/lib/components";
 
 ReactDOM.render(
 		<AppCatalog />

--- a/src-built-in/components/appCatalog/src/app.jsx
+++ b/src-built-in/components/appCatalog/src/app.jsx
@@ -10,16 +10,8 @@ import "../../../../assets/css/font-finance.css";
 import "../../../../assets/css/finsemble.css";
 import "../appCatalog.css";
 import "../../complexMenu/menu.css";
-import { AppCatalog } from "@chartiq/finsemble-ui/src/components/appCatalog/appCatalog";
+import { AppCatalog } from "@chartiq/finsemble-ui/lib/components/appCatalog/appCatalog";
 
-if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
-function FSBLReady() {
-	//console.log("App Catalog app onReady");
-	FSBL.Clients.WindowClient.finsembleWindow.updateOptions({ alwaysOnTop: true });
-	FSBL.Clients.DialogManager.showModal();
-	//FSBL.Clients.WindowClient.finsembleWindow.addEventListener("shown", FSBL.Clients.DialogManager.showModal);
-
-	ReactDOM.render(
+ReactDOM.render(
 		<AppCatalog />
 		, document.getElementById("bodyHere"));
-}

--- a/src-built-in/components/appCatalog/src/app.jsx
+++ b/src-built-in/components/appCatalog/src/app.jsx
@@ -9,47 +9,8 @@ import ReactDOM from "react-dom";
 import "../../../../assets/css/font-finance.css";
 import "../../../../assets/css/finsemble.css";
 import "../appCatalog.css";
-import ComplexMenu from "../../complexMenu/ComplexMenu";
-import AppContent from "./components/AppContent";
-
-
-/**
- * This is our application launcher. It is opened from a button in our sample toolbar, and it handles the launching of finsemble components.
- *
- * @class AppLauncher
- * @extends {React.Component}
- */
-class AppCatalog extends React.Component {
-	constructor(props) {
-		super(props);
-		this.state = {
-			loaded: false,
-			headerImgUrl: ""
-		};
-	}
-	componentWillMount() {
-		FSBL.Clients.ConfigClient.getValues(null, (err, config) => {
-			if (config.startup_app && config.startup_app.applicationIcon) {
-				//console.log("config.startup_app.applicationIcon", config.startup_app.applicationIcon)
-				this.setState({
-					loaded: true,
-					// headerImgUrl: config.startup_app.applicationIcon
-				});
-			}
-		})
-		this.setState({ activeSection: this.props && this.props.activeSection ? this.props.activeSection : '' })//Props did not exist in the constructor
-	}
-	render() {
-		var self = this;
-		if (!this.state.loaded) return null;
-		return (
-			<ComplexMenu headerImgUrl={this.state.headerImgUrl} title="App Catalog" activeSection="Apps" navOptions={[{
-				label: "Apps",
-				content: <AppContent installed={true} />
-			}]} />
-		);
-	}
-}
+import "../../complexMenu/menu.css";
+import { AppCatalog } from "@chartiq/finsemble-ui/src/components/appCatalog/appCatalog";
 
 if (window.FSBL && FSBL.addEventListener) { FSBL.addEventListener("onReady", FSBLReady); } else { window.addEventListener("FSBLReady", FSBLReady) }
 function FSBLReady() {


### PR DESCRIPTION
https://chartiq.kanbanize.com/ctrl_board/18/cards/22723/details/

Testing:
1. Checkout seed@`22723-wrap-appcatalog`
1. In toolbar's devtools run the following command to spawn app catalog
```javascript
FSBL.Clients.LauncherClient.spawn("App Catalog")
```