### PR TITLE
22719 toolbar responsiveness

### DIFF
--- a/assets/css/_toolbar.css
+++ b/assets/css/_toolbar.css
@@ -31,11 +31,11 @@
 }
 
 .finsemble-toolbar-section.right {
+    margin-left: auto;
     margin-right: 8px;
     justify-content: flex-end;
     order: 2;
-    flex: 1;
-    flex: auto;
+    flex: 0 0 auto;
 }
 
 .finsemble-toolbar-section.left {
@@ -101,10 +101,6 @@ span > svg {
 }
 
 @media screen and (max-width: 385px) {
-    .finsemble-toolbar-section.right {
-        display: none;
-    }
-
     .finsemble-toolbar-section.left .divider:last-of-type {
         display: none;
     }
@@ -115,11 +111,6 @@ span > svg {
     .finsemble-toolbar-section.center {
         display: none;
     }
-
-    .finsemble-toolbar-section.right .divider {
-        display: none;
-    }
-
 }
 
 .finsemble-toolbar-section.left > .finsemble-toolbar-button-label {

--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -9,29 +9,28 @@ import { ToolbarShell, DragHandle, FavoritesShell, RevealAll, MinimizeAll, AutoA
 import { FileMenu } from "./fileMenu";
 
 import '../toolbar.css';
-import { ExampleMenu, ExampleMenu2, AdvancedExample } from "./exampleMenu";
 const Toolbar = () => {
 	return (
 		<ToolbarShell>
-			<div className="finsemble-toolbar-section left">
+			<ToolbarSection className="left">
 				<DragHandle />
 				<FileMenu />
-				<Search/>
-				<WorkspaceManagementMenu/>
+				<Search />
+				<WorkspaceManagementMenu />
 				{/* Workspace Management Menu */}
 				{/* App Menu */}
-			</div>
+			</ToolbarSection>
 			<ToolbarSection className="center" minWidth={115}>
 				<div className="divider"></div>
 				<FavoritesShell />
 			</ToolbarSection>
-			<div className="finsemble-toolbar-section right">
-			<div className="divider"></div>
+			<ToolbarSection className="right">
+				<div className="divider"></div>
 				<MinimizeAll />
 				<AutoArrange />
 				<RevealAll />
-			</div>
-      <div className="resize-area" ></div>
+			</ToolbarSection>
+			<div className="resize-area" ></div>
 		</ToolbarShell>
 	)
 }

--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -22,9 +22,11 @@ const Toolbar = () => {
 				{/* App Menu */}
 			</div>
 			<div className="finsemble-toolbar-section center">
+				<div className="divider"></div>
 				<FavoritesShell />
 			</div>
 			<div className="finsemble-toolbar-section right">
+			<div className="divider"></div>
 				<MinimizeAll />
 				<AutoArrange />
 				<RevealAll />

--- a/src-built-in/components/toolbar/src/app.jsx
+++ b/src-built-in/components/toolbar/src/app.jsx
@@ -5,7 +5,7 @@
 import ReactDOM from "react-dom";
 import React from "react";
 
-import { ToolbarShell, DragHandle, FavoritesShell, RevealAll, MinimizeAll, AutoArrange, Search, WorkspaceManagementMenu } from "@chartiq/finsemble-ui/lib/components";
+import { ToolbarShell, DragHandle, FavoritesShell, RevealAll, MinimizeAll, AutoArrange, Search, WorkspaceManagementMenu, ToolbarSection } from "@chartiq/finsemble-ui/lib/components";
 import { FileMenu } from "./fileMenu";
 
 import '../toolbar.css';
@@ -21,10 +21,10 @@ const Toolbar = () => {
 				{/* Workspace Management Menu */}
 				{/* App Menu */}
 			</div>
-			<div className="finsemble-toolbar-section center">
+			<ToolbarSection className="center" minWidth={115}>
 				<div className="divider"></div>
 				<FavoritesShell />
-			</div>
+			</ToolbarSection>
 			<div className="finsemble-toolbar-section right">
 			<div className="divider"></div>
 				<MinimizeAll />

--- a/src-built-in/components/welcome/welcome.html
+++ b/src-built-in/components/welcome/welcome.html
@@ -1,26 +1,30 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-    <script src="../../vendor.bundle.js"></script>
+  <script src="../../vendor.bundle.js"></script>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>Welcome to Finsemble!</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-   <link rel="stylesheet" type="text/css" href="welcome.css">
-   <script src="../../vendor.bundle.js"></script>
-    <script src="welcome.js" ></script>
+  <link rel="stylesheet" type="text/css" href="welcome.css">
+  <script src="../../vendor.bundle.js"></script>
+  <script src="welcome.js"></script>
 </head>
+
 <body>
-<div id="container">
-<div id="bounds"></div>
-<div class="spacer1"></div>
-<img src="../../assets/img/finsembleDarkBG_noText.png" id="finsembleLogo" height="100">
-<div class="spacer2"></div>
-<h1>Welcome to Finsemble!</h1>
-<div class="spacer3"></div>
-<button class="button" id="launchTutorial" onclick="launchTutorial()">Launch Docs</button>
-<div class ="spacer4"></div>
-</div>
+  <div id="container">
+    <div id="bounds"></div>
+    <div class="spacer1"></div>
+    <img src="../../assets/img/finsembleDarkBG_noText.png" id="finsembleLogo" height="100">
+    <div class="spacer2"></div>
+    <h1>Welcome to Finsemble!</h1>
+    <div class="spacer3"></div>
+    <button class="button" id="launchTutorial" onclick="launchTutorial()">Launch Docs</button>
+    <div class="spacer4"></div>
+    <input type="text" value="WWWWW">
+  </div>
 </body>
+
 </html>


### PR DESCRIPTION
feat: #id [22719]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22719/details)

**Description of change**
* Created a new reusable react component `ToolbarSection`
* Added definition for ResizeObserver

**Description of testing**
1. Checkout finsemble-ui@22719ToolbarResponsiveness
1. `npm run dev` in both seed and ui
1. Resize toolbar to the minimum/maximum

The middle section where favorites are, should render when middle section is > 115px and should not render when its less than 115px. This number can be configured in `toolbar/src/app.jsx`

```jsx
<ToolbarSection className="center" minWidth={115}>
```

When  > 155px
https://app.zeplin.io/project/5a6b7dea31e01cd724fc9f60/screen/5e431d42bb5b28b3f8b762fa
When <= 115px
https://app.zeplin.io/project/5a6b7dea31e01cd724fc9f60/screen/5e446a19f7d497984077297e