### PR TITLE
fix: #id 22639 Don't add app to current custom folder

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -197,7 +197,6 @@ async function addApp(id, cb = Function.prototype) {
 		return app.appId === appID;
 	});
 	const name = app.title || app.name;
-	const folder = data.activeFolder;
 
 	if (app === undefined) {
 		console.warn("App not found.");
@@ -237,7 +236,6 @@ async function addApp(id, cb = Function.prototype) {
 	let folders = data.folders;
 
 	data.folders[ADVANCED_APP_LAUNCHER].apps[appID] = appConfig
-	data.folders[folder].apps[appID] = appConfig
 	FSBL.Clients.LauncherClient.registerComponent({
 		componentType: appConfig.name,
 		manifest: appConfig.manifest


### PR DESCRIPTION
fix: #id [22639]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22639/details)

**Description of change**
* Remove folder prop from `registerComponent`

**Description of testing**
1. Grab https://github.com/ChartIQ/fdc-appd and run `npm start`
1. Checkout seed@`22639-appacatalog-addapp`
1. Line 155 in seed config.json `"appDirectoryEndpoint": "http://localhost:3030/v1",`
1. Edit seed `src-built-in/components/toolbar/config.json` and set `menuType` to `Advanced App Launcher`
1. Edit seed `src-built-in\components\advancedAppLauncher\src\components\LeftNavBottomLinks.jsx` and uncomment line 8
1. Run seed `npm run dev-fresh`
1. Create a folder in the Advanced App Launcher
2. Open the Advanced App Catalog
3. Add an app to the Launcher using the Check mark icon on the app card.

- [x] The app should not be added to the current folder that you created in previous step.