### PR TITLE
fix: #id 22271 Take out depreciated toolbar config

### DIFF
--- a/configs/application/UIComponents.json
+++ b/configs/application/UIComponents.json
@@ -595,7 +595,7 @@
 				"docked": "top",
 				"canGroup": false,
 				"options": {
-					"autoShow": false,
+					"autoShow": true,
 					"contextMenu": false,
 					"showTaskbarIcon": false,
 					"smallWindow": true,
@@ -613,8 +613,9 @@
 				"services": {
 					"windowService": {
 						"allowAutoArrange": false,
-						"ignoreSnappingRequests": true,
-						"ignoreTilingAndTabbingRequests": true
+						"allowSnapping": false,
+						"allowTabbing": false,
+						"allowTiling": false
 					},
 					"workspaceService": {
 						"global": true

--- a/configs/application/UIComponents.json
+++ b/configs/application/UIComponents.json
@@ -595,7 +595,7 @@
 				"docked": "top",
 				"canGroup": false,
 				"options": {
-					"autoShow": true,
+					"autoShow": false,
 					"contextMenu": false,
 					"showTaskbarIcon": false,
 					"smallWindow": true,


### PR DESCRIPTION
fix: #id 22271

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22271/details/)

**Description of change**
* Took out depreciated toolbar config
* Set the "autoShow" flag inside the toolbar config to be true in case user set the workspaceService.global to be false (currently undocumented). In that case if we have autoShow set to be false, the toolbar would come up hidden.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Launch finsemble
1. Make sure toolbar shows up and cannot tab, tile, nor snap