### PR TITLE
22923 aac load components

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
@@ -30,14 +30,15 @@ const Header = props => {
 			// So lets spawn from URL
 			if (props.url) {
 				FSBL.Clients.LauncherClient.spawn(null, {
-					url: props.url
+					url: props.url,
+					addToWorkspace:true
 				}, () => {
 					pendingSpawn = false;
 				});
 				return;
 			}
 			// Otherwise launch application by name
-			FSBL.Clients.LauncherClient.spawn(name, {}, (err, data) => {
+			FSBL.Clients.LauncherClient.spawn(name, {addToWorkspace:true}, (err, data) => {
 				pendingSpawn = false;
 			});
 		} else {

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -166,13 +166,6 @@ function loadInstalledComponentsFromStore(cb = Function.prototype) {
 					console.error("there was an error loading from FDC3", component, err);
 					return componentDone();
 				}
-				// register the component with the launcher service
-				/*FSBL.Clients.LauncherClient.registerComponent({
-					componentType: component.name,
-					manifest: app.manifest
-				}, (err, response) => {
-					componentDone(err);
-				});*/
 			});
 		}
 		// We'll load our user defined components here

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -167,12 +167,12 @@ function loadInstalledComponentsFromStore(cb = Function.prototype) {
 					return componentDone();
 				}
 				// register the component with the launcher service
-				FSBL.Clients.LauncherClient.registerComponent({
+				/*FSBL.Clients.LauncherClient.registerComponent({
 					componentType: component.name,
 					manifest: app.manifest
 				}, (err, response) => {
 					componentDone(err);
-				});
+				});*/
 			});
 		}
 		// We'll load our user defined components here

--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -57,7 +57,7 @@ var Actions = {
 		});
 
 		//Whenever we add or remove a component, this event is fired. We get a list of all components, then filter it out to include only the ones that this particular launcher is capable of spawning.
-		FSBL.Clients.RouterClient.addListener("Launcher.update", function (err, response) {
+		FSBL.Clients.RouterClient.subscribe("Launcher.update", function (err, response) {
 			FSBL.Clients.Logger.debug("list updated", err, response);
 			if (err) {
 				return console.error(err);


### PR DESCRIPTION
fix: #id [22923]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22923/details)

**Moved load of AAC components to Startup**
* Components will be added to the Workspace when the "Open" button is clicked on their AAC page.
* SearchLauncher "listener" has been changed to a PubSub.
* Registration of components has been moved to Core instead of Seed.

**Description of testing**

1. Run Finsemble
1. Add a Sample Component to a Workspace via AAC.
1. Reload Finsemble and verify Sample Component
1. Verify that Sample Component is available via Toolbar Search.
1. No additional Central Logger Errors or Warnings that are not required were introduced by this PR