### PR TITLE
fix: 23161 fix tags styling on adv app launcher

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
@@ -69,7 +69,7 @@ export default class AppDefinition extends React.Component {
 		return (
 			<div onClick={this.onItemClick} className="app-item link" draggable="true" onDragStart={this.onDragToFolder}>
 				<span className="app-item-title">
-					<i onClick={(e) => { favoritesActionOnClick(e); }} style={!this.isFavorite() ? { color: "gray" } : null} className={this.isFavorite() ? 'ff-favorite' : 'ff-star-outline'}></i><span >{app.displayName || app.name}</span>
+					<i onClick={(e) => { favoritesActionOnClick(e); }} className={this.isFavorite() ? 'ff-favorite' : 'ff-star-outline'}></i><span >{app.displayName || app.name}</span>
 				</span>
 				{app.tags.length > 0 &&
 					<AppTagsList tags={app.tags} />}

--- a/src-built-in/components/advancedAppLauncher/style.css
+++ b/src-built-in/components/advancedAppLauncher/style.css
@@ -396,12 +396,14 @@ select:focus, option:focus {
     overflow: hidden;
     text-overflow: ellipsis;
     width: 390px;
+    margin-left: 30px;
     font-weight: var(--appMenu-tag-font-weight);
   }
 
   .app-item-tags i {
     padding-right: 6px;
     padding-top: 3px;
+    color: var(--core-primary-5);
   }
 
   .app-item:hover {
@@ -432,7 +434,7 @@ select:focus, option:focus {
     padding-top: 1px;
     padding-right: 7px;
     font-size: var(--appMenu-font-size);
-    color: var(--appMenu-app-favorite-color);
+    color: var(--core-primary-5);
   }
 
   .filter-sort {


### PR DESCRIPTION
Fix padding on tags.
Make grays consistent.
Reduce brightness of tag icon.
Remove hardcoded 'gray'