### PR TITLE
chore: #id 23340 Change the import path of the useAuth hook

### DIFF
--- a/src-built-in/components/authentication/Authentication.jsx
+++ b/src-built-in/components/authentication/Authentication.jsx
@@ -8,7 +8,7 @@
 import React, { useState } from "react";
 import ReactDOM from "react-dom";
 import { AuthHeader, AuthForm, ErrorMessage, AuthInput, AuthSubmit } from "@chartiq/finsemble-ui/react/components";
-import useAuth from "@chartiq/finsemble-ui/react/hooks";
+import { useAuth } from "@chartiq/finsemble-ui/react/hooks";
 
 export const Authentication = () => {
     const { saveInputChange, formValues, authorize, quitApplication } = useAuth();


### PR DESCRIPTION
chore: #id 23340

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/23340/details/)

**Description of change**
* Change the import path of the useAuth hook

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Modify the finsemble config to use authentication. Test along with https://github.com/ChartIQ/finsemble-ui/pull/36
1. Launch finsemble, make sure the authentication window shows up with no error in the console.