### PR TITLE
fix: #id 22626 Hover colors on active check need color differentiation

### DIFF
--- a/src-built-in/components/advancedAppCatalog/appCatalog.css
+++ b/src-built-in/components/advancedAppCatalog/appCatalog.css
@@ -269,6 +269,11 @@
 	color: var(--catalog-card-checkmark-selected-color);
 }
 
+.app-card .ff-check-mark-2.highlighted.added {
+	display: block;
+	color: var(--accent-positive-1);
+}
+
 .app-catalog {
 	display: flex;
 	flex-direction: column;

--- a/src-built-in/components/advancedAppCatalog/src/components/AppCard.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/AppCard.jsx
@@ -157,7 +157,8 @@ class AppCard extends Component {
 		let { appName, checkShown, checkHighlighted } = this.state;
 
 		let imageIconClasses = "ff-check-mark-2";
-		if (this.props.installed || checkHighlighted) imageIconClasses += " highlighted"
+		if (this.props.installed && checkHighlighted) imageIconClasses += " highlighted added";
+		else if (this.props.installed || checkHighlighted) imageIconClasses += " highlighted"
 		else imageIconClasses += " faded";
 
 		let titleClass = this.state.titleUnderlined ? "app-title highlighted" : "app-title";


### PR DESCRIPTION
fix: #id [22626]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/22626/details)

**Description of change**
* Adds another css class for when a checkmark is already active and gets hovered
* Added code to the AppCard to change the css state of the check depending on the state of installation and hover

**Description of testing**
1. Setup Finsemble and the advanced app launcher/catalog
1. Install an app
1. From a catalog screen containing app cards, notice the active checkmark (green to indicate installed). Hover over it and notice the change in green (subtle difference between light green and a darker green)
1. [ ] Hover state of active checkmark changed on hover