### PR TITLE
fix: #id 24432 Default to not show AOT button for Welcome Component

### DIFF
--- a/configs/application/components.json
+++ b/configs/application/components.json
@@ -34,7 +34,7 @@
 						"launchableByUser": true
 					},
 					"Window Manager": {
-						"alwaysOnTopIcon": true,
+						"alwaysOnTopIcon": false,
 						"showLinker": true,
 						"FSBLHeader": true,
 						"persistWindowState": true,


### PR DESCRIPTION
fix: #id 24432

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/24432/details/)

**Description of change**
* Default to not show AOT button for Welcome Component

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Launch finsemble and make sure the welcome component's titlebar does not have the always on top icon 