### PR TITLE
fix: #id 24413 fix null reference error in appLauncher

### DIFF
--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -123,7 +123,7 @@ var Actions = {
 	// Custom Components are always shown @TODO - make this a setting
 	filterComponents(components) {
 		var self = this;
-		var settings = FSBL.Clients.WindowClient.options.customData.spawnData;
+		var settings = FSBL.Clients.WindowClient.options.customData.spawnData || {};
 		var componentList = {};
 		var keys = Object.keys(components);
 		if (settings.mode) {


### PR DESCRIPTION
fix: #id [22413]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/24413/details)

**Description of change**

Added a check for null to `customData.spawnData` in `filterComponents` function.

**Description of testing**

I booted up Finsemble and verified the error wasn't there.
