### PR TITLE
fix: #id 25157 zoom preload should read component config zoom settings

### DIFF
--- a/src-built-in/preloads/zoom.js
+++ b/src-built-in/preloads/zoom.js
@@ -237,7 +237,21 @@ const runZoomHandler = () => {
 	insertPopUp();
 
 	// Update the zoom configuration.
-	FSBL.Clients.ConfigClient.getValue({ field: "finsemble.Window Manager.zoom" }, zoomConfigHandler);
+	FSBL.Clients.LauncherClient.getComponentDefaultConfig(FSBL.Clients.WindowClient.getWindowIdentifier().componentType, (err, componentConfig) => {
+		// Read component config for zoom
+		try {
+			zoomConfig = componentConfig.foreign.components["Window Manager"].zoom;
+			if (zoomConfig) {
+				return zoomConfigHandler(null, zoomConfig);
+			}
+		} catch(e) {
+			// component config does not have foreign or foreign.components
+		}
+
+		// If component doesn't have a config, read global config for zoom
+		FSBL.Clients.ConfigClient.getValue({ field: "finsemble.Window Manager.zoom" }, zoomConfigHandler);	
+		
+	});
 
 	// Create hot keys for zooming.
 	FSBL.Clients.HotkeyClient.addBrowserHotkey(["ctrl", "="], zoomIn);


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25157/details)

**Description of change**
* Changed the zoom preload to try to read the zoom config from the component config first
* If not present in component config, read the global config

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Added zoom config to the Welcome Component config and made sure it applied.
1. Removed zoom config from the Welcome Component and moved to the global "Window Manager" config and made sure it applied.
```
		"zoom": {
			"timeout": 4000,
			"step": 0.15,
			"min": 0.7,
			"max": 1.0
		}
```
