### PR TITLE
fix: #id 23320 advanced app launcher search no longer persists on restart

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/index.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/index.jsx
@@ -64,7 +64,6 @@ class AppLauncher extends React.Component {
 		}, (error, data) => {
 			error && console.log("Failed to set isFormVisible to false");
 		});
-		get
 	}
 
 	openAppMarket() {

--- a/src-built-in/components/advancedAppLauncher/src/index.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/index.jsx
@@ -25,10 +25,17 @@ class AppLauncher extends React.Component {
 	}
 
 	componentWillMount() {
-		getStore().addListener({ field: "isFormVisible" }, this.toggleAddNewAppForm);
+		const store = getStore();
+		store.addListener({ field: "isFormVisible" }, this.toggleAddNewAppForm);
 		finsembleWindow.addEventListener("shown", () => {
 			finsembleWindow.focus();
 		});
+		// Delete the search text from the store as searches should not persist over restart.
+		// The deletion is done on startup as a shutdown listener wouldn't trigger on crashes
+		store.setValue({
+			field: "filterText",
+			value: ""
+		})
 	}
 
 	componentWillUnmount() {
@@ -57,6 +64,7 @@ class AppLauncher extends React.Component {
 		}, (error, data) => {
 			error && console.log("Failed to set isFormVisible to false");
 		});
+		get
 	}
 
 	openAppMarket() {


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/23320/details)

**Description of change**
* Fixes an issue where advanced app launcher search persisted on restart. This is a port of the same fix in 5.0 from https://github.com/ChartIQ/finsemble-ui/pull/43. However, only a small amount of that fix is needed as the new menu portal structure in 5.0 changes how menus work. That fix also changed the behavior of search so that the results cleared on app selection. In 5.0, both toolbar search and advanced launcher search have that behavior. As toolbar search still maintains state on app launch in 4.3 that change was also not pulled into this fix to keep the behavior consistent.
* Clears the filtertext value in the store on launch, this value is used to populate the search results. The clear is done on launch instead of shutdown so the bug will be fixed on crashes/unclean shutdowns.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Tested that search results no longer persist on restart
2. Tested that search results continue to persist on menu open and close and app launch.