### PR TITLE
fix: #id 24086 read disable user remove

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppActionsMenu.jsx
@@ -148,7 +148,7 @@ export default class AppActionsMenu extends React.Component {
 		const apps = storeActions.getAllApps();
 		const app = apps[this.props.app.appID];
 		const folder = this.props.folder;
-		const canDelete = app.hasOwnProperty('disableUserRemove') ? app.disableUserRemove : true;
+		const canDelete = app.hasOwnProperty('canDelete') ? app.canDelete : true;
 		let favoritesActionOnClick = this.props.isFavorite ? this.onRemoveFromFavorite : this.onAddToFavorite;
 		let favoritesText = this.props.isFavorite ? "Remove from Favorites" : "Add to Favorites";
 		return (

--- a/src-built-in/components/advancedAppLauncher/src/components/AppActionsMenu.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppActionsMenu.jsx
@@ -148,6 +148,7 @@ export default class AppActionsMenu extends React.Component {
 		const apps = storeActions.getAllApps();
 		const app = apps[this.props.app.appID];
 		const folder = this.props.folder;
+		const canDelete = app.hasOwnProperty('disableUserRemove') ? app.disableUserRemove : true;
 		let favoritesActionOnClick = this.props.isFavorite ? this.onRemoveFromFavorite : this.onAddToFavorite;
 		let favoritesText = this.props.isFavorite ? "Remove from Favorites" : "Add to Favorites";
 		return (
@@ -155,7 +156,7 @@ export default class AppActionsMenu extends React.Component {
 				<ul>
 					<li onClick={favoritesActionOnClick}>{favoritesText}</li>
 					{app.source && app.source === FDC3 && <li onClick={this.onViewInfo}>View Info</li>}
-					{!app.source && <li onClick={this.deleteApp}>Delete App</li>}
+					{!app.source && canDelete && <li onClick={this.deleteApp}>Delete App</li>}
 					{[ADVANCED_APP_LAUNCHER, FAVORITES].indexOf(folder.name) === -1 &&
 						<li onClick={this.onRemove}>Remove from {folder.name}</li>}
 				</ul>

--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -225,6 +225,8 @@ export default class FoldersList extends React.Component {
 			nameField = folderName;
 		}
 
+		const canDelete = folder.hasOwnProperty('disableUserRemove') ? folder.disableUserRemove : false;
+
 		//This DOM will be rendered within a draggable (if the folder can be dragged), and a plain ol div if it cannot be dragged.
 		return (
 			<div onClick={(event) => this.onFolderClicked(event, folderName)}
@@ -236,7 +238,7 @@ export default class FoldersList extends React.Component {
 				</div>
 				{folder.icon === EDITABLE_FOLDER_ICON_CLASS && <span className='folder-action-icons'>
 					<i className='ff-adp-edit' title='Rename' onClick={this.renameFolder.bind(this, folderName)}></i>
-					<i className='ff-adp-trash-outline' title='Delete Folder' onClick={this.deleteFolder.bind(this, folderName)}></i>
+					{canDelete && <i className='ff-adp-trash-outline' title='Delete Folder' onClick={this.deleteFolder.bind(this, folderName)}></i>}
 				</span>}
 			</div>);
 	}

--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -225,7 +225,8 @@ export default class FoldersList extends React.Component {
 			nameField = folderName;
 		}
 
-		const canDelete = folder.hasOwnProperty('disableUserRemove') ? folder.disableUserRemove : false;
+		const canDelete = folder.hasOwnProperty('canDelete') ? folder.canDelete : false;
+		const canEdit = folder.hasOwnProperty('canEdit') ? folder.canEdit : false;
 
 		//This DOM will be rendered within a draggable (if the folder can be dragged), and a plain ol div if it cannot be dragged.
 		return (
@@ -236,10 +237,10 @@ export default class FoldersList extends React.Component {
 					{folder.icon && <i className={folder.icon}></i>}
 					<div className="folder-name">{nameField}</div>
 				</div>
-				{folder.icon === EDITABLE_FOLDER_ICON_CLASS && <span className='folder-action-icons'>
-					<i className='ff-adp-edit' title='Rename' onClick={this.renameFolder.bind(this, folderName)}></i>
+				<span className='folder-action-icons'>
+					{canEdit && <i className='ff-adp-edit' title='Rename' onClick={this.renameFolder.bind(this, folderName)}></i>}
 					{canDelete && <i className='ff-adp-trash-outline' title='Delete Folder' onClick={this.deleteFolder.bind(this, folderName)}></i>}
-				</span>}
+				</span>
 			</div>);
 	}
 	/**

--- a/src-built-in/components/advancedAppLauncher/src/components/LeftNavBottomLinks.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/LeftNavBottomLinks.jsx
@@ -5,7 +5,7 @@ import { getStore } from '../stores/LauncherStore'
 const bottomEntries = [
 	{ name: "New App", icon: "ff-new-workspace", click: "showAddAppForm" },
 	//{ name: 'New Dashboard', icon: 'ff-dashboard-new' },
-	// { name: "App Catalog", icon: "ff-list", click: "openAppMarket" }
+	{ name: "App Catalog", icon: "ff-list", click: "openAppMarket" }
 ];
 
 export default class LeftNavBottomLinks extends React.Component {

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -265,11 +265,12 @@ function getToolbarStore(done) {
 	});
 }
 
+
+/**
+ * Compares values in the AppLauncher store with a persisted version and restores any keys that have differences
+ * @param {*} done The callback to call when finished 
+ */
 function syncPersistenceStore(done) {
-
-	FSBL.Clients.ConfigClient.getValue()
-
-
 	//Creating a store will return the store if it already exists
 	FSBL.Clients.DistributedStoreClient.createStore({ global: true, persist: true, store: PERSISTENCE_STORE_NAME }, function (getStoreErr, store) {
 		if (getStoreErr) {


### PR DESCRIPTION
fix: #id [24086]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/24086/details)

**Description of change**
* `disableUserRemove` has been changed to `canDelete` and properly applied to folders/apps. Now the delete icon for a folder will show/not show depending on this property
* Added `canEdit` to the spec for folders to allow showing/hiding of edit icon
* When changes are made in the app catalog they are sent to a persistent store, this way, if the application is restarted and a foundation changes anything, the storage will be re-synced with persistence. This process only runs if the distributedStore is configured correctly

**Description of testing**
1. Seed advanced app launcher with the following config:
```
"distributedStore": {
            "alwaysRestoreFromFoundation": false,
            "initialStores": [
                {
                    "name": "Finsemble-AppLauncher-Store",
                    "foundation": {
                        "appFolders": {
                            "list": [
                                "Advanced App Launcher",
                                "Favorites",
                                "CanDeleteCanEdit",
                                "CanDeleteCantEdit",
                                "CantDeleteCanEdit",
                                "CantDeleteCantEdit"
                            ],
                            "folders": {
                                "Advanced App Launcher": {
                                    "icon": "ff-component",
                                    "type": "folder",
                                    "canDelete": false,
                                    "canEdit": false,
                                    "apps": {
                                        "1": {
                                            "name": "Welcome Component",
                                            "appID": "welcome-comp"
                                        },
                                        "2": {
                                            "name": "Getting Started Tutorial",
                                            "appID": "2"
                                        },
                                        "3": {
                                            "name": "Process Monitor",
                                            "appID": "pm"
                                        },
                                        "4": {
                                            "name": "Notepad",
                                            "appID": "note"
                                        }
                                    }
                                },
                                "Favorites": {
                                    "icon": "ff-favorite",
                                    "type": "folder",
                                    "canDelete": false,
                                    "canEdit": false,
                                    "apps": {}
                                },
                                "CanDeleteCanEdit": {
                                    "icon": "ff-component",
                                    "type": "folder",
                                    "canDelete": true,
                                    "canEdit": true,
                                    "apps": {}
                                },
                                "CanDeleteCantEdit": {
                                    "icon": "ff-component",
                                    "type": "folder",
                                    "canDelete": true,
                                    "canEdit": false,
                                    "apps": {}
                                },
                                "CantDeleteCanEdit": {
                                    "icon": "ff-component",
                                    "type": "folder",
                                    "canDelete": false,
                                    "canEdit": true,
                                    "apps": {}
                                },
                                "CantDeleteCantEdit": {
                                    "icon": "ff-component",
                                    "type": "folder",
                                    "canDelete": false,
                                    "canEdit": false,
                                    "apps": {}
                                }
                            }
                        },
                        "appDefinitions": {}
                    },
                    "default": {
                        "activeLauncherTags": [],
                        "filterText": "",
                        "filterTags": [],
                        "activeFolder": "Advanced App Launcher",
                        "sortBy": "Alphabetical"
                    }
                }
            ]
        }
```
1. Run Finsemble
1. When the advanced app launcher comes up, delete any folders that the icon is displayed for
1. Restart Finsemble
1. The app launcher should restore in the state you left it in (folders should still be removed even though they are still present in the foundation)
1. Change `alwaysRestoreFromFoundation` to true in the above snippet.
1. Restart Finsemble
1. The folders which were deleted should now have returned, having been restored from the foundation
1. [ ] Foundation seeding/persistence fallback works 