### PR TITLE
Fix position of searchClear 'x'

### DIFF
--- a/src-built-in/components/advancedAppLauncher/style.css
+++ b/src-built-in/components/advancedAppLauncher/style.css
@@ -575,9 +575,8 @@ select:focus, option:focus {
 	position: absolute;
 	z-index:1;
 	right: 68px;
-	top: -21px;
+	top: 13px;
     bottom: 0;
-    margin: auto;
 	padding: 3px 3px 2px 2px;
 	border-radius: 50%;
 	text-align: center;


### PR DESCRIPTION
**Description of change**
* In Advanced App Launcher, if a tag was added to the search, the searchClear 'x' would shift downwards. This prevents that from happening.

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Enable Advanced App Launcher
1. Put some text into the search.
1. Add a tag to the search.
1. See if the 'X" switches position up or down...it shouldn't.