### PR TITLE
fix: #id 25633 new Channels don't show up

### DIFF
--- a/src-built-in/components/linker/src/stores/linkerStore.js
+++ b/src-built-in/components/linker/src/stores/linkerStore.js
@@ -51,6 +51,8 @@ var LinkerStore = Object.assign({}, EventEmitter.prototype, {
 			}
 
 			self.setState(queryMessage.data);
+			// deal with the case of added linker channels
+			FSBL.Clients.WindowClient.fitToDOM();
 			FSBL.Clients.Logger.system.log("toggle Linker window");
 			queryMessage.sendQueryResponse(null, {});
 		});


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25633/details)

**Description of change**
* Call FitToDOM each time the window shows to account for new channels.

See companion finsemble PR - 
https://github.com/ChartIQ/finsemble/pull/1894