### PR TITLE
feat: #id 25360  Change makeInstaller task to check for cert password on env

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -578,7 +578,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 					installerConfig.certificatePassword = certPassphraseFromEnv.trim();
 				} else {
 					// If a certificate file was provided and a password can't be found, show error and exit
-					throw new Error(`A certificate file was provided but a password cannot be found. Please provide one as plain text in the config or as an environment variable: INSTALLER_CERTIFICATE_PASSPHRASE`);
+					throw new Error(`A certificate file was provided but a password cannot be found. Please provide one as in the config or as an environment variable: INSTALLER_CERTIFICATE_PASSPHRASE`);
 				}
 			}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -578,7 +578,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 					installerConfig.certificatePassword = certPassphraseFromEnv.trim();
 				} else {
 					// If a certificate file was provided and a password can't be found, show error and exit
-					throw new Error(`A certificate file was provided but a password cannot be found. Please provide one as in the config or as an environment variable: INSTALLER_CERTIFICATE_PASSPHRASE`);
+					throw new Error(`A certificate file was provided but a password cannot be found. Please provide one in the config or as an environment variable: INSTALLER_CERTIFICATE_PASSPHRASE`);
 				}
 			}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -578,7 +578,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 					installerConfig.certificatePassword = certPassphraseFromEnv.trim();
 				} else {
 					// If a certificate file was provided and a password can't be found, show error and exit
-					throw new Error(`A certificate file was provided but a password cannot be found. Please provide on as plain text in the config, or as an environment variable: CERTIFICATE_PASSWORD`);
+					throw new Error(`A certificate file was provided but a password cannot be found. Please provide one as plain text in the config or as an environment variable: INSTALLER_CERTIFICATE_PASSPHRASE`);
 				}
 			}
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,6 +25,7 @@ const { launch, connect } = require('hadouken-js-adapter');
 	const FEA = FEA_PATH_EXISTS ? require("@chartiq/finsemble-electron-adapter/exports") : undefined;
 	const FEAPackager = FEA ? FEA.packager : undefined;
 	const MAX_NODE_VERSION = '12.13.1';
+	const INSTALLER_CERT_PASS = "INSTALLER_CERTIFICATE_PASSPHRASE";
 
 	// local
 	const extensions = fs.existsSync("./gulpfile-extensions.js") ? require("./gulpfile-extensions.js") : undefined;
@@ -567,6 +568,18 @@ const { launch, connect } = require('hadouken-js-adapter');
 			//check if we have an installer config matching the environment name, if not assume we just have a single config for all environments
 			if (installerConfig[env.NODE_ENV]) {
 				installerConfig = installerConfig[env.NODE_ENV];
+			}
+
+			if (installerConfig.certificateFile) {
+				const certPassphraseFromEnv = process.env[INSTALLER_CERT_PASS];
+
+				//If a certificate file is provided and a plain text password is not, look for environment variable
+				if (!installerConfig.certificatePassword && certPassphraseFromEnv) {
+					installerConfig.certificatePassword = certPassphraseFromEnv.trim();
+				} else {
+					// If a certificate file was provided and a password can't be found, show error and exit
+					throw new Error(`A certificate file was provided but a password cannot be found. Please provide on as plain text in the config, or as an environment variable: CERTIFICATE_PASSWORD`);
+				}
 			}
 
 			// need absolute paths for certain installer configs


### PR DESCRIPTION
feat: #id [25360]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25360/details)

**Description of change**
* Installer builder checks env variable for cert passphrase

**Required PRs**
Finsemble: https://github.com/ChartIQ/finsemble/pull/1887
FEA: https://github.com/ChartIQ/finsemble-electron-adapter/pull/234

**Description of testing**
1. Provide a cert file in the installer.json
1. Build an installer with `INSTALLER_CERTIFICATE_PASSPHRASE=***** npm run makeInstaller:prod` where **** is the password to the  provided certificate
1. [ ] Installer built with certification