### PR TITLE
Fallback to cert file if json password is missing; throw error if bot…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -570,11 +570,11 @@ const { launch, connect } = require('hadouken-js-adapter');
 				installerConfig = installerConfig[env.NODE_ENV];
 			}
 
-			if (installerConfig.certificateFile) {
+			if (installerConfig.certificateFile && !installerConfig.certificatePassword) {
 				const certPassphraseFromEnv = process.env[INSTALLER_CERT_PASS];
 
 				//If a certificate file is provided and a plain text password is not, look for environment variable
-				if (!installerConfig.certificatePassword && certPassphraseFromEnv) {
+				if (certPassphraseFromEnv) {
 					installerConfig.certificatePassword = certPassphraseFromEnv.trim();
 				} else {
 					// If a certificate file was provided and a password can't be found, show error and exit


### PR DESCRIPTION
fix: #id [25363]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25363/details)

**Description of change**
* Only throw error if  both command line password and json password are omitted

**Description of testing**
See: https://github.com/ChartIQ/finsemble-seed/pull/671