### PR TITLE
fix: #id 21949 21949 aal title bug

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppShowcase.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/AppShowcase.jsx
@@ -136,7 +136,7 @@ class AppShowcase extends Component {
 						</span>
 					</div>
 				)}
-				<Header iconUrl={iconUrl} name={this.props.app.name} entitled={this.state.entitled} installed={this.props.app.installed} appId={this.props.app.appId} />
+				<Header iconUrl={iconUrl} entitled={this.state.entitled} {...this.props.app} />
 
 				<ImageCarousel nextImage={this.nextImage} previousImage={this.previousImage} openModal={this.openModal} images={images} />
 


### PR DESCRIPTION
fix: #id [21949]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/21949/details)

**Description of change**
* Passes entire app from Showcase to Header to allow name or title access

**Description of testing**
1. Open Finsemble with Advanced App Launcher and Advanced App Catalog enabled
1. Start example fdc-appd server with json from ticket: https://chartiq.kanbanize.com/ctrl_board/106/cards/21949/details/
1. Add and open the only app in the provided json. Launch from the app catalog
1. [ ] App should launch without issues