### PR TITLE
feat: #id 25975 additional typescript support

### DIFF
--- a/build/webpack/defaultWebpackConfig.js
+++ b/build/webpack/defaultWebpackConfig.js
@@ -100,7 +100,7 @@ module.exports = class WebpackDefaults {
 						}
 					},
 					{
-						test: /\.tsx?$/,
+						test: /\.ts(x)?$/,
 						loader: 'ts-loader',
 						exclude: /node_modules/
 					}

--- a/build/webpack/webpack.preloads.js
+++ b/build/webpack/webpack.preloads.js
@@ -4,8 +4,8 @@ const { EnvironmentPlugin, ProgressPlugin } = require("webpack");
 
 let entries = {};
 for (let key in preloadFilesToBuild) {
-	let component = preloadFilesToBuild[key];
-	entries[component.output] = component.entry;
+    let component = preloadFilesToBuild[key];
+    entries[component.output] = component.entry;
 }
 
 module.exports = {
@@ -25,6 +25,11 @@ module.exports = {
                     cacheDirectory: './.babel_cache/',
                     presets: ['react', 'stage-1']
                 }
+            },
+            {
+                test: /\.ts(x)?$/,
+                loader: 'ts-loader',
+                exclude: /node_modules/
             }
         ]
     },
@@ -34,6 +39,6 @@ module.exports = {
         path: path.resolve(__dirname, '../../dist/')
     },
     resolve: {
-        extensions: ['.js', '.jsx', '.json', 'scss', 'html']
+        extensions: ['.ts', '.tsx', '.js', '.jsx', '.json', 'scss', 'html']
     },
 };

--- a/build/webpack/webpack.services.js
+++ b/build/webpack/webpack.services.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require("fs");
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const glob_entries = require('webpack-glob-entries');
-const services = glob_entries(path.join(__dirname, '../../', "/src/services/**/*.js"));
+const services = glob_entries(path.join(__dirname, '../../', "/src/services/**/*.*s"));
 let entry = {};
 
 //process service files found

--- a/build/webpack/webpack.services.js
+++ b/build/webpack/webpack.services.js
@@ -2,7 +2,7 @@ const path = require('path');
 const fs = require("fs");
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const glob_entries = require('webpack-glob-entries');
-const services = glob_entries(path.join(__dirname, '../../', "/src/services/**/*.*s"));
+const services = glob_entries(path.join(__dirname, '../../', "/src/services/**/*.{js,ts}"));
 let entry = {};
 
 //process service files found

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
         "style-loader": "0.19.1",
         "ts-loader": "3.5.0",
         "tslint": "5.11.0",
-        "typescript": "3.2.4",
+        "typescript": "3.9.3",
         "uglifyjs-webpack-plugin": "1.2.7",
         "url-join": "2.0.5",
         "url-loader": "0.6.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"jsx": "react",
 		"target": "es2017",
 		"module": "commonjs",
 		"noImplicitAny": true,


### PR DESCRIPTION
[Kanban link](https://chartiq.kanbanize.com/ctrl_board/106/cards/25995/details/)

**Description of change**
Added the ability to build typescript files when using preload and services from src
* Changes
- Webpack configs changed and tsconfig added react for tsx
- updated typscript dependency to latest (3.9.3)

**Description of testing**
- Create a typescript service, it should build correctly in the dist folder.
- Create a typescript preload, add it to the preloads.entries file and it should build correctly to the dist folder. 
- Try the above with JSX - preloads should build 