### PR TITLE
Fix favorites folder display/apps calculation

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -5,7 +5,7 @@
 import AppDirectory from "../modules/AppDirectory";
 import FDC3 from "../modules/FDC3";
 import { getStore } from "./appStore";
-import { findIndex } from 'lodash';
+import { findAppIndexInFolder } from '../utils/helpers';
 import * as path from "path";
 export default {
 	initialize,
@@ -127,12 +127,6 @@ function _removeActiveTag(tag) {
  */
 function _clearActiveTags() {
 	getStore().setValue({ field: "activeTags", value: [] });	
-}
-
-function _findAppIndexInFolder(appID, folderName) {
-	return findIndex(data.folders[folderName].apps, app => {
-		return app.appID === appID;
-	});
 }
 
 
@@ -286,7 +280,7 @@ function removeApp(id, cb = Function.prototype) {
 			}
 
 			for (const key in data.folders) {
-				const appIndex = _findAppIndexInFolder(id, key);
+				const appIndex = findAppIndexInFolder(id, key);
 				if (appIndex > -1) {
 					folders[key].apps.splice(appIndex, 1);
 				}

--- a/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
+++ b/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
@@ -1,0 +1,7 @@
+import { getStore } from '../stores/appStore';
+
+export const findAppIndexInFolder = (appID, folderName) => {
+    const folders = getStore().getValue("appFolders.folders");
+    
+    return findIndex(folders[folderName].apps, app => app.appID === appID);
+}

--- a/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import AppActionsMenu from "./AppActionsMenu";
 import AppTagsList from "./AppTagsList";
 import storeActions from "../stores/StoreActions";
+import { findIndex } from 'lodash';
 const DEFAULT_APP_ICON = "ff-component";
 const FAVORITES = "Favorites";
 /**
@@ -59,8 +60,11 @@ export default class AppDefinition extends React.Component {
 		storeActions.removePin(this.props.app);
 	}
 	isFavorite() {
-		let favorites = Object.keys(storeActions.getSingleFolder("Favorites").apps);
-		return favorites.indexOf(this.props.app.appID.toString()) > -1;
+		let favorites = storeActions.getSingleFolder("Favorites").apps;
+		const favoriteIndex =  findIndex(favorites, (favorite) => {
+			return this.props.app.appID.toString() === favorite.appID.toString();
+		})
+		return favoriteIndex > -1;
 	}
 	render() {
 		const app = this.props.app;

--- a/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
@@ -60,7 +60,7 @@ export default class AppDefinition extends React.Component {
 		storeActions.removePin(this.props.app);
 	}
 	isFavorite() {
-		let favorites = storeActions.getSingleFolder("Favorites").apps;
+		const favorites = storeActions.getSingleFolder("Favorites").apps;
 		const favoriteIndex =  findIndex(favorites, (favorite) => {
 			return this.props.app.appID.toString() === favorite.appID.toString();
 		})

--- a/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import AppActionsMenu from "./AppActionsMenu";
 import AppTagsList from "./AppTagsList";
 import storeActions from "../stores/StoreActions";
-import { findIndex } from 'lodash';
+import { isAppInFavorites } from '../utils/helpers';
 const DEFAULT_APP_ICON = "ff-component";
 const FAVORITES = "Favorites";
 /**
@@ -59,25 +59,19 @@ export default class AppDefinition extends React.Component {
 		storeActions.removeAppFromFolder(FAVORITES, this.props.app);
 		storeActions.removePin(this.props.app);
 	}
-	isFavorite() {
-		const favorites = storeActions.getSingleFolder("Favorites").apps;
-		const favoriteIndex =  findIndex(favorites, (favorite) => {
-			return this.props.app.appID.toString() === favorite.appID.toString();
-		})
-		return favoriteIndex > -1;
-	}
 	render() {
 		const app = this.props.app;
+		const isFavorite = isAppInFavorites(app.appID);
 		if (typeof (app.icon) === "undefined" || app.icon === null) app.icon = DEFAULT_APP_ICON;
-		let favoritesActionOnClick = this.isFavorite() ? this.onRemoveFromFavorite : this.onAddToFavorite;
+		let favoritesActionOnClick = isFavorite ? this.onRemoveFromFavorite : this.onAddToFavorite;
 		return (
 			<div onClick={this.onItemClick} className="app-item link" draggable="true" onDragStart={this.onDragToFolder}>
 				<span className="app-item-title">
-					<i onClick={(e) => { favoritesActionOnClick(e); }} className={this.isFavorite() ? 'ff-favorite' : 'ff-star-outline'}></i><span >{app.displayName || app.name}</span>
+					<i onClick={(e) => { favoritesActionOnClick(e); }} className={isFavorite ? 'ff-favorite' : 'ff-star-outline'}></i><span >{app.displayName || app.name}</span>
 				</span>
 				{app.tags.length > 0 &&
 					<AppTagsList tags={app.tags} />}
-				<AppActionsMenu app={app} folder={this.props.folder} isFavorite={this.isFavorite()} />
+				<AppActionsMenu app={app} folder={this.props.folder} isFavorite={isFavorite} />
 			</div>
 		);
 	}

--- a/src-built-in/components/advancedAppLauncher/src/components/Content.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/Content.jsx
@@ -36,7 +36,7 @@ export default class Content extends React.Component {
 		if (folder.name === ADVANCED_APP_LAUNCHER) {
 			apps = Object.values(storeActions.getAllApps());
 		} else {
-			apps = Object.values(folder.apps);
+			apps = folder.apps;
 		}
 
 

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -577,7 +577,7 @@ function findAppByField(field, value) {
 
 function getActiveFolder() {
 	const folder = data.folders[data.activeFolder];
-	Object.values(folder.apps).map((app) => {
+	folder.apps.map((app) => {
 		const appData = findAppByField('appID', app.appID)
 		if (!appData) {
 			app.tags = [];

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -3,6 +3,7 @@ import { findIndex } from 'lodash';
 import { getStore } from "./LauncherStore";
 import AppDirectory from "../modules/AppDirectory";
 import FDC3 from "../modules/FDC3";
+import { findAppIndexInFolder } from '../utils/helpers';
 const async = require("async");
 let FDC3Client;
 let appd;
@@ -316,12 +317,6 @@ function _setFolders(cb = Function.prototype) {
 	});
 }
 
-function _findAppIndexInFolders(appID, folderName) {
-	return findIndex(data.folders[folderName].apps, app => {
-		return app.appID === appID;
-	});
-}
-
 function addPin(pin) {
 	//TODO: This logic may not work for dashboards. Might need to revisit.
 	FSBL.Clients.LauncherClient.getComponentList((err, components) => {
@@ -459,7 +454,7 @@ function deleteApp(appID) {
 		}
 		// Delete app from any folder that has it
 		for (const key in data.folders) {
-			const appIndex = _findAppIndexInFolders(appID, key);
+			const appIndex = findAppIndexInFolder(appID, key);
 			data.folders[key].apps.splice(appIndex,  1);
 		}
 
@@ -550,7 +545,7 @@ function renameFolder(oldName, newName) {
 }
 
 function addAppToFolder(folderName, app) {
-	const appIndex = _findAppIndexInFolders(app.appID, folderName);
+	const appIndex = findAppIndexInFolder(app.appID, folderName);
 
 	if (appIndex < 0) {
 		data.folders[folderName].apps.push({
@@ -563,7 +558,7 @@ function addAppToFolder(folderName, app) {
 }
 
 function removeAppFromFolder(folderName, app) {
-	const appIndex = _findAppIndexInFolders(app.appID, folderName);
+	const appIndex = findAppIndexInFolder(app.appID, folderName);
 	data.folders[folderName].apps.splice(appIndex, 1);
 	_setFolders();
 }

--- a/src-built-in/components/advancedAppLauncher/src/utils/helpers.js
+++ b/src-built-in/components/advancedAppLauncher/src/utils/helpers.js
@@ -1,0 +1,15 @@
+import { findIndex } from 'lodash';
+import storeActions from '../stores/StoreActions';
+
+export const findAppIndexInFolder = (appID, folderName) => {
+	const folder = storeActions.getSingleFolder(folderName);
+	return findIndex(folder.apps, app => app.appID === appID);
+}
+
+export const isAppInFavorites = (appID) => {
+	const favorites = storeActions.getSingleFolder('Favorites').apps;
+	const index = findAppIndexInFolder(appID, favorites);
+
+	if (index < 0)  return false;
+	return true;
+}

--- a/src-built-in/components/advancedAppLauncher/src/utils/sort-functions.js
+++ b/src-built-in/components/advancedAppLauncher/src/utils/sort-functions.js
@@ -1,4 +1,5 @@
 import storeActions from '../stores/StoreActions'
+import { findIndex } from 'lodash';
 
 export default {
 	/**
@@ -16,10 +17,9 @@ export default {
 	 * for apps that are in Favorite folder
 	 */
 	Favorites: (list) => {
-		const favorites = storeActions.getSingleFolder('Favorites').apps;
 		return list.sort((a, b) => {
-			const aInFavorites = a.appID in favorites;
-			const bInFavorites = b.appID in favorites;
+			const aInFavorites = isAppInFavorites(a.appID);
+			const bInFavorites = isAppInFavorites(b.appID);
 			// a component being in favorites means it is "less than" another component not in favorites, so return -1
 			if (aInFavorites && !bInFavorites) 
 			{
@@ -32,4 +32,12 @@ export default {
 			return a.name.localeCompare(b.name);
 		});
 	}
+}
+
+const isAppInFavorites = (appID) => {
+	const favorites = storeActions.getSingleFolder('Favorites').apps;
+	const index = findIndex(favorites, favorite => favorite.appID === appID);
+
+	if (index < 0)  return false;
+	return true;
 }

--- a/src-built-in/components/advancedAppLauncher/src/utils/sort-functions.js
+++ b/src-built-in/components/advancedAppLauncher/src/utils/sort-functions.js
@@ -1,5 +1,4 @@
-import storeActions from '../stores/StoreActions'
-import { findIndex } from 'lodash';
+import { isAppInFavorites } from './helpers';
 
 export default {
 	/**
@@ -32,12 +31,4 @@ export default {
 			return a.name.localeCompare(b.name);
 		});
 	}
-}
-
-const isAppInFavorites = (appID) => {
-	const favorites = storeActions.getSingleFolder('Favorites').apps;
-	const index = findIndex(favorites, favorite => favorite.appID === appID);
-
-	if (index < 0)  return false;
-	return true;
 }


### PR DESCRIPTION
fix: #id [26156]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/26156/details)

**Description of change**
* Changes how apps inside folders are read in due to changes in the  underlying data structure

**Description of testing**
1. Setup Finsemble with Advanced App Launcher
1. Favorite an app
1. Ensure the app appears on the  toolbar and the star is filled in
1. Clicking to favorite again should do the opposite