### PR TITLE
fix: #id 26161 Fix helper issues and don't add catalog app to activeFolder

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
@@ -65,7 +65,7 @@ const Header = props => {
 					) : (
 							<span className="action-button-label">
 								Add
-						</span>
+							</span>
 						)}
 				</button>
 				{props.installed && <button className={props.entitled ? "action-button remove" : "action-button remove disabled"} disabled={!props.entitled} onClick={removeApp}>

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -239,7 +239,6 @@ async function addApp(id, cb = Function.prototype) {
 	let folders = data.folders;
 
 	data.folders[ADVANCED_APP_LAUNCHER].apps.push(appConfig);
-	if (folder !== ADVANCED_APP_LAUNCHER) data.folders[folder].apps.push(appConfig);
 	FSBL.Clients.LauncherClient.registerComponent({
 		componentType: appConfig.name,
 		manifest: appConfig.manifest
@@ -280,7 +279,7 @@ function removeApp(id, cb = Function.prototype) {
 			}
 
 			for (const key in data.folders) {
-				const appIndex = findAppIndexInFolder(id, key);
+				const appIndex = findAppIndexInFolder(id, key, data.folders);
 				if (appIndex > -1) {
 					folders[key].apps.splice(appIndex, 1);
 				}

--- a/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
+++ b/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
@@ -1,5 +1,4 @@
 import { findIndex } from 'lodash';
-import { getStore } from '../stores/appStore';
 
 export const findAppIndexInFolder = (appID, folderName, folders) => {
     return findIndex(folders[folderName].apps, app => app.appID === appID);

--- a/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
+++ b/src-built-in/components/advancedAppCatalog/src/utils/helpers.js
@@ -1,7 +1,6 @@
+import { findIndex } from 'lodash';
 import { getStore } from '../stores/appStore';
 
-export const findAppIndexInFolder = (appID, folderName) => {
-    const folders = getStore().getValue("appFolders.folders");
-    
+export const findAppIndexInFolder = (appID, folderName, folders) => {
     return findIndex(folders[folderName].apps, app => app.appID === appID);
 }

--- a/src-built-in/components/advancedAppLauncher/src/utils/helpers.js
+++ b/src-built-in/components/advancedAppLauncher/src/utils/helpers.js
@@ -7,8 +7,7 @@ export const findAppIndexInFolder = (appID, folderName) => {
 }
 
 export const isAppInFavorites = (appID) => {
-	const favorites = storeActions.getSingleFolder('Favorites').apps;
-	const index = findAppIndexInFolder(appID, favorites);
+	const index = findAppIndexInFolder(appID, "Favorites");
 
 	if (index < 0)  return false;
 	return true;


### PR DESCRIPTION
fix: #id [26161]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/26161/details)

**Description of change**
* Fix errors in catalog and launcher helpers trying to access folder data
* Don't add catalog added app to active launcher folder

**Description of testing**
1. Run Finsemble with Advanced App Laucher and Advanced App Catalog
1. Highlight any folder in the launcher other than the main 'App Launcher' folder
1. Add and app from the catalog's  showcase page
1. [ ] App did not appear  in highlighted folder and was only added to the main folder