### PR TITLE
fix: #id 25683 Don't submit rename if newName is same as oldName

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -185,7 +185,7 @@ export default class FoldersList extends React.Component {
 		if (oldName.trim() === newName.trim()) nameChanged = false;
 
 		// Names must be unique, folders cant share same names
-		if (folders[newName] && nameChanged) {
+		if (folders[newName]) {
 			let repeatedFolderIndex = 0;
 			do {
 				repeatedFolderIndex++;

--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -168,6 +168,7 @@ export default class FoldersList extends React.Component {
 		const input = this.state.folderNameInput.trim()
 		const oldName = this.state.renamingFolder;
 		let newName = input;
+
 		// Check user input to make sure its at least 1 character
 		// made of string, number or both
 		if (!/^([a-zA-Z0-9\s]{1,})$/.test(input)) {
@@ -177,8 +178,14 @@ export default class FoldersList extends React.Component {
 				isNameError: true
 			});
 		}
+
+		// Check if the submission is the same text as the old name.
+		// If false, renaming will be skipped
+		let nameChanged = true;
+		if (oldName.trim() === newName.trim()) nameChanged = false;
+
 		// Names must be unique, folders cant share same names
-		if (folders[newName]) {
+		if (folders[newName] && nameChanged) {
 			let repeatedFolderIndex = 0;
 			do {
 				repeatedFolderIndex++;
@@ -191,7 +198,9 @@ export default class FoldersList extends React.Component {
 			renamingFolder: null,
 			isNameError: false
 		}, () => {
-			storeActions.renameFolder(oldName, newName)
+			if (nameChanged) {
+				storeActions.renameFolder(oldName, newName)
+			}
 			// No need for the click listener any more
 			this.removeClickListener()
 		})


### PR DESCRIPTION
fix: #id [25683]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25683/details)

**Description of change**
* When a user submits a rename of a folder the new text is checked against the old folder name. If the values are equal the rename is not submitted

**Description of testing**
1. Run Finsemble configured with Advanced App Launcher
1. Create a custom folder with any name
1. Rename the folder. In the input, type in the same name the folder had before the rename
1. [ ] Folder name returned when submitted and a "(1)" was not appended