### PR TITLE
fix: #id 26141 Fix styling of add button on app showcase page in advanced app catalog

### DIFF
--- a/src-built-in/components/advancedAppCatalog/appCatalog.css
+++ b/src-built-in/components/advancedAppCatalog/appCatalog.css
@@ -687,6 +687,7 @@
 .app-showcase .header .action-button-label {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	width: 100%;
 	height: 16px;
 	font-size: 12px;


### PR DESCRIPTION
fix: #id [26141]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/26141/details)

**Description of change**
* Center css content inside of showcase button

**Description of testing**
1. Run Finsemble with  Advanced App Launcher and Advanced App Catalog
1. Open an app's  showcase
1. [ ] Ensure the 'Add' button has equal spacing on either side inside the button