### PR TITLE
fix: #id 25678 Flash input when folder name is invalid. Fix folder reordering issues

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -265,8 +265,8 @@ export default class FoldersList extends React.Component {
 			if (isEditing) {
 				buttons = (
 					<span className='folder-action-icons'>
-						{canDelete && <i id='confirm-edit' className='ff-check-mark-2' title='Accept Rename' onClick={this.renameFolder.bind(this, folderName)}></i>}
-						{canEdit && <i id='cancel-edit' className='ff-close' title='Cancel' onClick={this.cancelEdit}></i>}
+						<i id='confirm-edit' className='ff-check-mark-2' title='Accept Rename' onClick={this.renameFolder.bind(this, folderName)}></i>
+						<i id='cancel-edit' className='ff-close' title='Cancel' onClick={this.cancelEdit}></i>
 					</span>
 				);
 			} else {

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -382,7 +382,7 @@ function getFoldersList() {
 }
 
 function getAllApps() {
-	let mergedApps = Object.assign({}, data.apps, data.configComponents);;
+	let mergedApps = Object.assign({}, data.apps, data.configComponents);
 	return mergedApps;
 }
 
@@ -395,6 +395,7 @@ function getSingleFolder(folderName) {
 }
 
 function reorderFolders(destIndex, srcIndex) {
+	console.log('destIndex: ', destIndex);
 	//There are two types of folders: Those that can be arranged, and those that cannot. We don't want to reorder the folders relative to the unorderable folders. Split them out, and then combine them after doing the filtering/swapping.
 	const dragDisabled = getDragDisabled();
 	const unorderableFolders = data.foldersList.filter(folderName => dragDisabled.includes(folderName));
@@ -407,6 +408,14 @@ function reorderFolders(destIndex, srcIndex) {
 		movedFolder,
 		...remainingItems.slice(srcIndex)
 	];
+
+	data.foldersList.map((folderName, i) => {
+		if (data.folders[folderName].order) {
+			data.folders[folderName].order = i;
+		}
+	});
+
+	_setValue("appFolders.folders", data.folders);
 	_setValue("appFolders.list", data.foldersList);
 	return data.foldersList;
 }
@@ -490,7 +499,8 @@ function addNewFolder(name) {
 		icon: "ff-adp-hamburger",
 		canEdit: true,
 		canDelete: true,
-		apps: []
+		apps: [],
+		order: Object.keys(data.folders).length
 	};
 	data.folders[folderName] = newFolder;
 	_setFolders(() => {
@@ -524,6 +534,13 @@ function renameFolder(oldName, newName) {
 	let oldFolder = data.folders[oldName];
 	data.folders[newName] = oldFolder;
 	delete data.folders[oldName];
+
+	// If the folder being renamed is the activeFolder, activeFolder needs to be set
+	// to the new folder name
+	if (data.activeFolder === oldName) {
+		_setValue('activeFolder', newName);
+	}
+
 	_setFolders(() => {
 		let indexOfOld = data.foldersList.findIndex((folderName) => {
 			return folderName === oldName;
@@ -540,7 +557,6 @@ function renameFolder(oldName, newName) {
 		}
 
 		_setValue("appFolders.list", data.foldersList);
-		delete data.folders[oldName];
 	});
 }
 

--- a/src-built-in/components/advancedAppLauncher/style.css
+++ b/src-built-in/components/advancedAppLauncher/style.css
@@ -51,8 +51,26 @@ img {
 }
 
 .complex-menu-section-toggle #rename.error {
-    border-bottom: 1px solid var(--appMenu-search-input-error-color);
+    border-bottom: solid 1px var(--appMenu-search-input-error-color);
+    animation-name: animate_error;
+    animation-duration: 900ms;
+    animation-iteration-count: 2;
+    animation-timing-function: linear;
 }
+
+@keyframes animate_error {
+    0% {
+        /* border-bottom: solid 1px var(--appMenu-search-input-active-color); */
+        border-bottom: solid 1px var(--appMenu-search-input-error-color);
+    }
+    50% {
+        border-bottom: solid 1px var(--appMenu-search-input-active-color);
+    }
+    100% {
+        border-bottom: 1px solid var(--appMenu-search-input-error-color);
+    }
+}
+
 
 .complex-menu-wrapper {
     display: flex;

--- a/src-built-in/components/advancedAppLauncher/style.css
+++ b/src-built-in/components/advancedAppLauncher/style.css
@@ -148,6 +148,7 @@ img {
     color: var(--appMenu-icon-color);
     display: flex;
     justify-content: space-between;
+    align-self: center;
     align-items: center;
     width: 45px;
 }
@@ -160,6 +161,22 @@ img {
     padding-top: 2px;
     padding-right: 4px;
     transition: .2s all;
+}
+
+.folder-action-icons .ff-check-mark-2 {
+    transition: .2s all;
+    color: var(--accent-positive);
+}
+
+.folder-action-icons .ff-close {
+    padding-top: 2px;
+    padding-right: 4px;
+    transition: .2s all;
+    color: var(--accent-negative);
+}
+
+.folder-action-icons .ff-close:hover {
+    color: var(--accent-negative-1);
 }
 
 .folder-action-icons .ff-adp-trash-outline:hover {


### PR DESCRIPTION
fix: #id [25678]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/25678/details)

**Description of change**
* Changes how folder order is maintained
* Keeps focus on invalid name inputs and prevents user from editing other folders until conflicts are resolved
* Adds an animation to input to indicate error

**Description of testing**
1. Start Finsemble with Advanced App Launcher enabled
1. Add a folder
1. Rename the folder to some text that is invalid like "@@"
1. Try to take focus off the input/submit. The input bottom border should flash red to indicate invalid input
1. [ ] Unable to edit other folders/unable to stop editing a folder in error