### PR TITLE
fix: #id 26172 26172 fix launch from catalog

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
@@ -38,7 +38,7 @@ const Header = props => {
 				return;
 			}
 			// Otherwise launch application by name
-			FSBL.Clients.LauncherClient.spawn(name, {addToWorkspace:true}, (err, data) => {
+			FSBL.Clients.LauncherClient.spawn(props.name, {addToWorkspace:true}, (err, data) => {
 				pendingSpawn = false;
 			});
 		} else {


### PR DESCRIPTION
fix: #id [26172]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/26172/details)

**Description of change**
* When an app is launched from the catalog and it isn't a url based component, always launch using the apps name, never the title.

**Description of testing**
1. Launch Finsemble configured with Advanced App Launcher and Advanced App Catalog
1. Add an app from the catalog
1. Launch the app using the newly appeared 'Open' button
1. Kill the appd server
1. Restart finsemble, saving the desktop
1. When finsemble restarts, the app added/started from the app catalog should still launch without any problems
1. [ ] App continued to launch after restarts without appd server running