### PR TITLE
fix: suprious error in seed

### DIFF
--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -126,6 +126,11 @@ var Actions = {
 		var settings = FSBL.Clients.WindowClient.options.customData.spawnData;
 		var componentList = {};
 		var keys = Object.keys(components);
+		// these settings should never be null, but they are on startup, which causes a type error.  Needs further investigation.
+		if (!settings) {
+			settings = {};
+			FSBL.Clients.Logger.system.warn("appLauncherStore.js: null settings");
+		}
 		if (settings.mode) {
 			if (!Array.isArray(settings.mode)) { settings.mode = [settings.mode]; }
 			keys.forEach((componentType) => {


### PR DESCRIPTION
Prevents App Launcher Startup Error

**Description of change**
* if settings are null, log a warning and initialize with empty struct to prevent error

