### PR TITLE
fix: #id 21949 Fixes to FDC3 apps re-registering at startup

### DIFF
--- a/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
+++ b/src-built-in/components/advancedAppCatalog/src/components/Showcase/Header.jsx
@@ -38,7 +38,7 @@ const Header = props => {
 				return;
 			}
 			// Otherwise launch application by name
-			FSBL.Clients.LauncherClient.spawn(props.name, {addToWorkspace:true}, (err, data) => {
+			FSBL.Clients.LauncherClient.spawn(name.trim(), {addToWorkspace:true}, (err, data) => {
 				pendingSpawn = false;
 			});
 		} else {

--- a/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
+++ b/src-built-in/components/advancedAppCatalog/src/stores/storeActions.js
@@ -224,10 +224,11 @@ async function addApp(id, cb = Function.prototype) {
 			appConfig = installed[appID] = {
 				appID,
 				tags: app.tags,
-				name,
+				name: name.trim(),
 				type: "component",
 				manifest,
-				canDelete: true
+				canDelete: true,
+				source: "FDC3"
 			}
 		}
 	} else {

--- a/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/AppDefinition.jsx
@@ -39,7 +39,7 @@ export default class AppDefinition extends React.Component {
 			finsembleWindow.hide();
 		}, 100);
 		const name = this.props.app.title || this.props.app.name;
-		FSBL.Clients.LauncherClient.spawn(name, {
+		FSBL.Clients.LauncherClient.spawn(name.trim(), {
 			addToWorkspace: true
 		});
 	}

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -212,18 +212,19 @@ function loadInstalledComponentsFromStore(cb = Function.prototype) {
 			// get the app info so we can load it into the launcher
 			return getApp(component.appID, (err, app) => {
 				if (err) {// don't want to kill this;
-					deleteApp(component.appID);
 					console.error("there was an error loading from FDC3", component, err);
 					return componentDone();
 				}
+				componentDone();
 			});
 		}
 		// We'll load our user defined components here
 		FSBL.Clients.LauncherClient.addUserDefinedComponent(component, (compAddErr) => {
 			if (compAddErr) {
 				console.warn("Failed to add new app:", compAddErr);
+				return componentDone(compAddErr);
 			}
-			componentDone(compAddErr);
+			componentDone();
 		});
 	}, (err) => {
 		cb(err);


### PR DESCRIPTION
fix: #id [21949]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/21949/details)

**Description of change**
* Trims names so no extra spaces through  off adding/launching of apps
* Ensures component loading completes in all cases (error or success)

**Description of testing**
1. Install an app from the advanced app catalog
1. Add the app to the workspace
1. Kill the server
1. Restart Finsemble - the app will load as an 'unconfigured component' because the information could not be loaded from the server
1. Restart the appd server and restart finsemble
1. Windows should reload
1. [ ] Windows loaded unconfigured when server was down and returned when server was back up