### PR TITLE
Allow editing of folders with any icon and correct permissions

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
+++ b/src-built-in/components/advancedAppLauncher/src/components/FoldersList.jsx
@@ -130,7 +130,7 @@ export default class FoldersList extends React.Component {
 		e.stopPropagation();
 		this.setState({
 			renamingFolder: name
-		})
+		});
 		this.addClickListener()
 	}
 
@@ -212,10 +212,11 @@ export default class FoldersList extends React.Component {
 			className += ' folder-with-icon'
 		}
 
-		const EDITABLE_FOLDER_ICON_CLASS = 'ff-adp-hamburger'
+		const canDelete = folder.canDelete;
+		const canEdit = folder.canEdit;
 
 		let nameField;
-		if (folder.icon === EDITABLE_FOLDER_ICON_CLASS && this.state.renamingFolder === folderName) {
+		if (this.state.renamingFolder === folderName && canEdit) {
 			nameField = <input id="rename" value={this.state.folderNameInput}
 			onChange={this.changeFolderName}
 			onKeyPress={this.keyPressed} className={this.state.isNameError ? "error" : ""} autoFocus />;
@@ -224,9 +225,6 @@ export default class FoldersList extends React.Component {
 		} else {
 			nameField = folderName;
 		}
-
-		const canDelete = folder.canDelete;
-		const canEdit = folder.canEdit;
 
 		//This DOM will be rendered within a draggable (if the folder can be dragged), and a plain ol div if it cannot be dragged.
 		return (


### PR DESCRIPTION
fix: #id [24086]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/24086/details)

**Description of change**
* Checks for ability to edit before exposing input for folder renaming
* Removed unneeded check for folder icon

**Description of testing**
1. Add custom folder with foundation that can be edited
1. Click edit icon of configured folder and ensure editing begins
1. [ ] Custom foundation added folder can be edited 