### PR TITLE
fix: #id 26676 26681 fixes for app launcher

### DIFF
--- a/configs/application/config.json
+++ b/configs/application/config.json
@@ -6,7 +6,7 @@
 			"initialStores": [
 				{
 					"name": "Finsemble-AppLauncher-Store",
-					"preferPreviousState": false,
+					"preferPreviousState": true,
 					"foundation": {
 						"appFolders": {
 							"list": ["Advanced App Launcher", "Favorites"],

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -525,6 +525,7 @@ function renameFolder(oldName, newName) {
 	let oldFolder = data.folders[oldName];
 	data.folders[newName] = oldFolder;
 	delete data.folders[oldName];
+
 	_setFolders(() => {
 		let indexOfOld = data.foldersList.findIndex((folderName) => {
 			return folderName === oldName;
@@ -538,6 +539,12 @@ function renameFolder(oldName, newName) {
 			const deletedFolders = data.deleted;
 			deletedFolders.splice(index, 1);
 			_setValue("deleted", deletedFolders);
+		}
+
+		// If the active folder is the folder being renamed, change that value
+		if (data.activeFolder === oldName) {
+			data.activeFolder = newName;
+			_setValue("activeFolder", data.activeFolder);
 		}
 
 		_setValue("appFolders.list", data.foldersList);

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -420,7 +420,8 @@ function addApp(app = {}, cb) {
 		tags: app.tags !== "" ? app.tags.split(",") : [],
 		name: app.name,
 		url: app.url,
-		type: "component"
+		type: "component",
+		canDelete: true // Users can delete quick components
 	};
 	const { FAVORITES } = getConstants();
 


### PR DESCRIPTION
fix: #id [26676]
fix: #id [26681]

[26672](https://chartiq.kanbanize.com/ctrl_board/18/cards/26676/details)
[26681](https://chartiq.kanbanize.com/ctrl_board/18/cards/26681/details)

**Description of change**
* Adds `canDelete` to components created with quick add form
* If renamed folder is active folder, resets activeFolder

**Description of testing**
1. Run Finsemble with Advanced App Launcher
1. Create a custom folder and click on it so the view for the new folder is selected. Rename the folder.
1. [ ] Renaming the folder doesn't cause any errors
1. Restart Finsemble and  ensure the launcher continues to open without errors
1. [ ] Can be restarted after editing a folder name
1. Add a quick component using the built in form
1. [ ] Quick component can be deleted using the context menu