### PR TITLE
Aal new structure transform

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -95,6 +95,7 @@ function initialize(callback = Function.prototype) {
 		}
 
 		data.folders = store.values.appFolders.folders;
+		validateFolderDataStructure();
 		data.foldersList = folderList || Object.keys(store.values.appFolders.folders);
 		data.apps = Object.keys(appList).length > 0 ? appList : store.values.appDefinitions;
 		data.tags = store.values.activeLauncherTags;
@@ -144,6 +145,25 @@ function appInAppList(appName) {
 	let app = findAppByField('name', appName);
 	return Boolean(app);
 }
+
+/**
+ * Ensures all 'apps' properties on folders conform
+ * to the new structure (Array vs object)
+ */
+function validateFolderDataStructure() {
+	Object.keys(data.folders).map(folderName => {
+		const folder = data.folders[folderName];
+		if (!Array.isArray(folder.apps)) {
+			const newApps = [];
+			Object.values(folder.apps).map(app => {
+				newApps.push(app);
+			});
+			folder.apps = newApps;
+		}
+	});
+	_setFolders(data.folders);
+}
+
 //Update apps in folders with updated config information
 function updateAppsInFolders(cb = Function.prototype) {
 	//Loop through folders and update apps with new info

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -154,7 +154,7 @@ function validateFolderDataStructure() {
 	Object.keys(data.folders).map(folderName => {
 		const folder = data.folders[folderName];
 		if (!Array.isArray(folder.apps)) {
-			const warning = "Application Launcher Persistent Store has data stored in deprecated format";
+			const warning = "Application Launcher Persistent Store has data stored in deprecated format. Please check distributedStore configs";
 			// If the structure is wrong, notify the user in hopes that the foundation will be fixed
 			FSBL.Clients.Logger.warn(warning);
 			FSBL.UserNotification.alert("system", "ONCE-SINCE-STARTUP", "Distributed Store Type Mismatch", warning);

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -154,7 +154,7 @@ function validateFolderDataStructure() {
 	Object.keys(data.folders).map(folderName => {
 		const folder = data.folders[folderName];
 		if (!Array.isArray(folder.apps)) {
-			const warning = "Advanced App Launcher distributed store foundation appears to use incorrect format. Please ensure all folders[folderName].apps are arrays instead of objects";
+			const warning = "Application Launcher Persistent Store has data stored in deprecated format";
 			// If the structure is wrong, notify the user in hopes that the foundation will be fixed
 			FSBL.Clients.Logger.warn(warning);
 			FSBL.UserNotification.alert("system", "ONCE-SINCE-STARTUP", "Distributed Store Type Mismatch", warning);

--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -154,6 +154,11 @@ function validateFolderDataStructure() {
 	Object.keys(data.folders).map(folderName => {
 		const folder = data.folders[folderName];
 		if (!Array.isArray(folder.apps)) {
+			const warning = "Advanced App Launcher distributed store foundation appears to use incorrect format. Please ensure all folders[folderName].apps are arrays instead of objects";
+			// If the structure is wrong, notify the user in hopes that the foundation will be fixed
+			FSBL.Clients.Logger.warn(warning);
+			FSBL.UserNotification.alert("system", "ONCE-SINCE-STARTUP", "Distributed Store Type Mismatch", warning);
+			
 			const newApps = [];
 			Object.values(folder.apps).map(app => {
 				newApps.push(app);


### PR DESCRIPTION
fix: #id [27837]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/27837/details)

**Description of change**
* Checks for folder[folderName].apps instances that are still typeof === "object" and converts them to arrays.
* If a conversion takes place, a Central Logger warning is logged, and a user notification is alerted

**Description of testing**
1. Run Finsemble 4.2 with the advanced app launcher and add some folders with some apps in them
1. Upgrade to 4.3 without clearing state
1. [ ] The launcher should come up, and Finsemble should throw an alert warning that the data structure is incorrect
1. [ ] The warning will only show once unless the distributed store is set to reseed on every run, until the foundation is fixed, the warning will be received everytime