### PR TITLE
27392 fix workspace menu

### DIFF
--- a/src-built-in/components/userPreferences/src/app.jsx
+++ b/src-built-in/components/userPreferences/src/app.jsx
@@ -31,6 +31,9 @@ class UserPreferences extends React.Component {
 		UserPreferencesStore.addListener({ field: "activeSection" }, this.setActiveSection);
 	}
 	setActiveSection(err, data) {
+		// Update workspaces every time the view changes to get up-to-date information
+		UserPreferencesActions.getWorkspaces();
+
 		this.setState({
 			activeSection: data.value
 		});

--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { WorkspaceManagementMenuStore, Store as UserPreferencesStore } from "../../stores/UserPreferencesStore";
+import { WorkspaceManagementMenuStore, Store as UserPreferencesStore, Actions as UserPreferencesActions } from "../../stores/UserPreferencesStore";
 import { FinsembleDnDContext, FinsembleDraggable, FinsembleDroppable } from '@chartiq/finsemble-react-controls';
 import Checkbox from '../checkbox';
 import async from 'async';
+import { Actions } from '../../../../processMonitor/src/stores/ProcessMonitorStore';
 class WorkspaceEditor extends React.Component {
 	constructor(props) {
 		super(props);
@@ -274,7 +275,6 @@ export default class Workspaces extends React.Component {
 	}
 	setPreferences(err, data) {
 		if (!data && !data.value) return;
-		console.log("Set preferences", data.value);
 		this.setState({
 			workspaceToLoadOnStart: data.value['finsemble.initialWorkspace'],
 			focusedWorkspace: data.value['finsemble.initialWorkspace']
@@ -307,6 +307,7 @@ export default class Workspaces extends React.Component {
 				if (err) {
 					console.error(err);
 				}
+
 				if (typeof cb === "function") {
 					cb();
 				}

--- a/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
+++ b/src-built-in/components/userPreferences/src/components/content/Workspaces.jsx
@@ -3,7 +3,6 @@ import { WorkspaceManagementMenuStore, Store as UserPreferencesStore, Actions as
 import { FinsembleDnDContext, FinsembleDraggable, FinsembleDroppable } from '@chartiq/finsemble-react-controls';
 import Checkbox from '../checkbox';
 import async from 'async';
-import { Actions } from '../../../../processMonitor/src/stores/ProcessMonitorStore';
 class WorkspaceEditor extends React.Component {
 	constructor(props) {
 		super(props);

--- a/src-built-in/components/workspaceManagementMenu/src/components/workspaceList.jsx
+++ b/src-built-in/components/workspaceManagementMenu/src/components/workspaceList.jsx
@@ -51,7 +51,10 @@ export default class WorkspaceManagementList extends React.Component {
 	render() {
 		let self = this;
 
-		let workspaces = this.props.workspaces.map(function (workspace, i) {
+		let workspaces = this.props.workspaces.map(function (workspaceName, i) {
+			const workspace = {
+				name: workspaceName
+			};
 			//Separate array for each workspace. This way, the activeWorkspace can be rendered without a trashcan.
 			let workspaceActions = [
 				{

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -52,7 +52,7 @@ Actions = {
 	},
 	initialize: function () {
 		//Gets the workspace list and sets the value in the store.
-		FSBL.Clients.WorkspaceClient.getWorkspaces(function (err, workspaces) {
+		FSBL.Clients.WorkspaceClient.getWorkspaceNames(function (err, workspaces) {
 			Logger.system.debug("WorkspaceManagementStore init getWorkspaces", workspaces);
 			WorkspaceManagementStore.setValue({ field: "WorkspaceList", value: workspaces });
 		});
@@ -267,12 +267,17 @@ Actions = {
 	},
 	reorderWorkspaceList: function (changeEvent) {
 		if (!changeEvent.destination) return;
-		let workspaces = JSON.parse(JSON.stringify(WorkspaceManagementStore.getValue({ field: 'WorkspaceList' })));
-		let workspaceToMove = JSON.parse(JSON.stringify(workspaces[changeEvent.source.index]));
+		let workspaces = WorkspaceManagementStore.getValue({ field: 'WorkspaceList' });
+		let workspaceToMove = workspaces[changeEvent.source.index];
 		workspaces.splice(changeEvent.source.index, 1);
 		workspaces.splice(changeEvent.destination.index, 0, workspaceToMove);
+		const workspacesWithExpectedStructure = workspaces.map((WSName) => {
+			return {
+				name: WSName
+			};
+		});
 		FSBL.Clients.WorkspaceClient.setWorkspaces({
-			workspaces: workspaces
+			workspaces: workspacesWithExpectedStructure
 		});
 		WorkspaceManagementStore.setValue({ field: "WorkspaceList", value: workspaces });
 	},


### PR DESCRIPTION
fix: #id [27392]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/27392/details)

**Description of change**
* Updates preferences components whenever the view changes to get most up-to-date workspace information
* Removes the constant workspace updates for every action slowing UI down
* Adds a private method to WorkspaceClient to retrieve a list of workspace names
* Adds a method to WorkspaceClient to retrieve the publish update constants to be used by a front end component to potentially filter out constant updates
* Switches name lists over to new method to retrieve workspace names

**Description of testing**
1. Open the preferences component after enabling import/export
1. Make changes to workspaces using the Preferences component/workspace menu and ensure changes are reflected in both places
1. [ ] Changes are reflected across all UIs expecting workspace changes