### PR TITLE
fix: #id 27392 Fix workspace menu issues regarding updates

### DIFF
--- a/src-built-in/components/userPreferences/src/app.jsx
+++ b/src-built-in/components/userPreferences/src/app.jsx
@@ -31,6 +31,9 @@ class UserPreferences extends React.Component {
 		UserPreferencesStore.addListener({ field: "activeSection" }, this.setActiveSection);
 	}
 	setActiveSection(err, data) {
+		// Update workspaces every time the view changes to get up-to-date information
+		UserPreferencesActions.getWorkspaces();
+		
 		this.setState({
 			activeSection: data.value
 		});

--- a/src-built-in/components/workspaceManagementMenu/src/components/workspaceList.jsx
+++ b/src-built-in/components/workspaceManagementMenu/src/components/workspaceList.jsx
@@ -51,7 +51,10 @@ export default class WorkspaceManagementList extends React.Component {
 	render() {
 		let self = this;
 
-		let workspaces = this.props.workspaces.map(function (workspace, i) {
+		let workspaces = this.props.workspaces.map(function (workspaceName, i) {
+			const workspace = {
+				name: workspaceName
+			};
 			//Separate array for each workspace. This way, the activeWorkspace can be rendered without a trashcan.
 			let workspaceActions = [
 				{

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -52,7 +52,7 @@ Actions = {
 	},
 	initialize: function () {
 		//Gets the workspace list and sets the value in the store.
-		FSBL.Clients.WorkspaceClient.getWorkspaces(function (err, workspaces) {
+		FSBL.Clients.WorkspaceClient.getWorkspaceNames(function (err, workspaces) {
 			Logger.system.debug("WorkspaceManagementStore init getWorkspaces", workspaces);
 			WorkspaceManagementStore.setValue({ field: "WorkspaceList", value: workspaces });
 		});
@@ -267,12 +267,17 @@ Actions = {
 	},
 	reorderWorkspaceList: function (changeEvent) {
 		if (!changeEvent.destination) return;
-		let workspaces = JSON.parse(JSON.stringify(WorkspaceManagementStore.getValue({ field: 'WorkspaceList' })));
-		let workspaceToMove = JSON.parse(JSON.stringify(workspaces[changeEvent.source.index]));
+		let workspaces = WorkspaceManagementStore.getValue({ field: 'WorkspaceList' });
+		let workspaceToMove = workspaces[changeEvent.source.index];
 		workspaces.splice(changeEvent.source.index, 1);
 		workspaces.splice(changeEvent.destination.index, 0, workspaceToMove);
+		const workspacesWithExpectedStructure = workspaces.map((WSName) => {
+			return {
+				name: WSName
+			};
+		});
 		FSBL.Clients.WorkspaceClient.setWorkspaces({
-			workspaces: workspaces
+			workspaces: workspacesWithExpectedStructure
 		});
 		WorkspaceManagementStore.setValue({ field: "WorkspaceList", value: workspaces });
 	},


### PR DESCRIPTION
fix: #id [27392]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/27392/details)

**Description of change**
* Updates preferences components whenever the view changes to get most up-to-date workspace information
* Removes the constant workspace updates for every action slowing UI down
* Adds a private method to WorkspaceClient to retrieve a list of workspace names
* Adds a method to WorkspaceClient to retrieve the publish update constants to be used by a front end component to potentially filter out constant updates
* Switches name lists over to new method to retrieve workspace names

**Description of testing**
1. Open the preferences component after enabling import/export
1. Make changes to workspaces using the Preferences component/workspace menu and ensure changes are reflected in both places
1. [ ] Changes are reflected across all UIs expecting workspace changes