### PR TITLE
Fix central logger error

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -166,7 +166,7 @@ function validateFolderDataStructure() {
 			folder.apps = newApps;
 		}
 	});
-	_setFolders(data.folders);
+	_setFolders();
 }
 
 //Update apps in folders with updated config information


### PR DESCRIPTION
Fixes an issue of calling to update folders and providing a parameter that will cause a type mismatch.

![image](https://user-images.githubusercontent.com/50030302/88720194-77469980-d0f2-11ea-870f-256c523b519a.png)
