### PR TITLE
fix startup error in app launcher

### DIFF
--- a/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
+++ b/src-built-in/components/appLauncher/src/stores/appLauncherStore.js
@@ -123,7 +123,7 @@ var Actions = {
 	// Custom Components are always shown @TODO - make this a setting
 	filterComponents(components) {
 		var self = this;
-		var settings = FSBL.Clients.WindowClient.options.customData.spawnData;
+		var settings = FSBL.Clients.WindowClient.options.customData.spawnData || {};
 		var componentList = {};
 		var keys = Object.keys(components);
 		if (settings.mode) {


### PR DESCRIPTION
**Description of change**
* assigned setting to empty object if it was undefined.

**Description of testing**
1. No error in central logger at startup
1. App Launcher still works
