### PR TITLE
fix: #id 28431 - Refactor of Dirty State

### DIFF
--- a/src-built-in/components/fileMenu/src/stores/fileMenuStore.js
+++ b/src-built-in/components/fileMenu/src/stores/fileMenuStore.js
@@ -101,10 +101,10 @@ var Actions = {
 		FSBL.Clients.LauncherClient.showWindow({
 			componentType: "UserPreferences"
 		}, {
-				monitor: "mine",
-				left: "center",
-				top: "center"
-			});
+			monitor: "mine",
+			left: "center",
+			top: "center"
+		});
 	},
 	/**
 	 * Called on shutdown (if the workspace is dirty).
@@ -113,11 +113,13 @@ var Actions = {
 	 * @returns
 	 */
 	saveWorkspace() {
-		if (!(PROMPT_ON_DIRTY && FSBL.Clients.WorkspaceClient.activeWorkspace.isDirty)) {
+		if (!PROMPT_ON_DIRTY) {
 			return Promise.resolve();
 		}
 
-		return new Promise((resolve, reject) => {
+		return new Promise(async (resolve, reject) => {
+			const isDirty = await FSBL.Clients.WorkspaceClient.isWorkspaceDirty();
+			if (!isDirty) return resolve();
 			FSBL.Clients.DialogManager.open("yesNo",
 				{
 					title: "Save your workspace?",

--- a/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
+++ b/src-built-in/components/workspaceManagementMenu/src/stores/workspaceManagementMenuStore.js
@@ -348,7 +348,7 @@ Actions = {
 	/**
 	 * Asks the user if they'd like to save their data, then loads the requested workspace.
 	 */
-	switchToWorkspace: function (data) {
+	switchToWorkspace: async function (data) {
 		// if a workspace prompt is outstanding for a previous switch, immediately return to lock out user from doing another switch (until responding to prompt);
 		// note this prompting flag is cleared in Actions.onAsyncComplete when the previous switch completes (after user responds to the prompt)
 		let prompting = Actions.getIsPromptingUser()
@@ -387,7 +387,7 @@ Actions = {
 		 * If the workspace is dirty, we need to do more than if it's clean. We don't want users to lose unsaved work.
 		 */
 		let tasks = [];
-		if (activeWorkspace.isDirty) {
+		if (await FSBL.Clients.WorkspaceClient.isWorkspaceDirty()) {
 			Actions.setIsPromptingUser(true);
 			let firstMethod = Actions.autoSave,
 				secondMethod = null;
@@ -515,9 +515,9 @@ Actions = {
 	/**
 	 * Asks the user if they'd like to save their workspace if it's different from what's in storage. If the workspace is clean, we just invoke the callback.
 	 */
-	askIfUserWantsToSave: function (callback) {
+	askIfUserWantsToSave: async function (callback) {
 		let activeWorkspace = WorkspaceManagementStore.getValue("activeWorkspace");
-		if (activeWorkspace.isDirty) {
+		if (await FSBL.Clients.WorkspaceClient.isWorkspaceDirty()) {
 			Logger.system.log("NewWorkspace.spawnDialog start.");
 			let dialogParams = {
 				title: "Save your workspace?",


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/28431/details/

**Description of change**
* use workspaceclient.isWorkspaceDirty() because the isDirty property is no longer valid.

**Description of testing**
1. Spawn a few HTML components
1. Save workspace
1. Reload should not prompt
1. Add a window to the workspace
1. Reload should prompt to save
1. Add a window to the workspace and close it
1. Reload should not prompt
1. Move a window
1. Reload should prompt to save