### PR TITLE
Adds default client logging config to manifest for customer facing ex…

### DIFF
--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -90,6 +90,17 @@
                     "serverAddress": "ws://127.0.0.1:3376"
                 }
             }
+        },
+        "logger": {
+            "defaultClientLogLevels": {
+                "Error": true, 
+                "Warn": true, 
+                "Info": false, 
+                "Log": true, 
+                "Debug": false, 
+                "Verbose": false, 
+                "LocalOnly": false
+            }
         }
     }
 }


### PR DESCRIPTION
…ample

fix: #id [28643]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/28643/details)

**Description of change**
* Adds manifest config for default client logging levels

**Description of testing**
1. Test with Finsemble PR 2003: https://github.com/ChartIQ/finsemble/pull/2003