### PR TITLE
28710 tabbing tiling bug

### DIFF
--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -128,6 +128,7 @@ export default class TabRegion extends React.Component {
         // We don't want onDropHandler() in windowTitleBarComponent.jsx
         // to handle this drop event, so we call event.stopPropagation().
         e.stopPropagation();
+        debugger;
         FSBL.Clients.Logger.system.debug("Tab stopDrag.");
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,
@@ -138,8 +139,10 @@ export default class TabRegion extends React.Component {
         FSBL.Clients.WindowClient.getBounds(
             (err, bounds) => {
                 // We ONLY want to know if we're in the tab region!
+                // The window drag region prevents a tab from being dropped on the very top pixel
+                // so adding a single pixel to the tab region fixes the calculation for isPointInBox
                 const tabRegion = {
-                    top: boundingBox.top + bounds.top,
+                    top: boundingBox.top + bounds.top + 1,
                     bottom: boundingBox.bottom + bounds.top,
                     left: boundingBox.left + bounds.left,
                     right: boundingBox.right + bounds.left 

--- a/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
+++ b/src-built-in/components/windowTitleBar/src/components/center/TabRegion.jsx
@@ -128,7 +128,6 @@ export default class TabRegion extends React.Component {
         // We don't want onDropHandler() in windowTitleBarComponent.jsx
         // to handle this drop event, so we call event.stopPropagation().
         e.stopPropagation();
-        debugger;
         FSBL.Clients.Logger.system.debug("Tab stopDrag.");
         this.mousePositionOnDragEnd = {
             x: e.nativeEvent.screenX,


### PR DESCRIPTION
…egion

fix: #id [28710]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/28710/details)

**Description of change**
* Adds a pixel to the determined drop zone to determine if the pixel is dropped in the _actual_ tab region or not

**Description of testing**
1. Drag a tab a single pixel above its tab region to recieve a mouse icon indicating a disabled drop (circle with cross through it)
1. Drop the tab in this area
1. [ ] Ensure Finsemble doesn't get 'stuck' in tiling/tabbing mode and tabs can still be moved around/mousing over other windows does not show a scrim