### PR TITLE
fix: #id 28956 Add apps with string id

### DIFF
--- a/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
+++ b/src-built-in/components/advancedAppLauncher/src/stores/StoreActions.js
@@ -466,7 +466,7 @@ function reorderFolders(destIndex, srcIndex) {
 }
 
 function addApp(app = {}, cb) {
-	const appID = (new Date()).getTime();
+	const appID = (new Date()).getTime() + "";
 	const folder = data.activeFolder;
 	const newAppData = {
 		appID,


### PR DESCRIPTION
fix: #id [28956]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/28956/details)

**Description of change**
* Manually added 'quick apps' convert ids to strings

**Description of testing**
1. Manually add an app to the Advanced App Launcher using the "New Component" button
1. Drag the app into some folders
1. Restart finsemble and attempt to open the AAL
1. [ ] Menu opened without errors