### PR TITLE
Move electron 'disableZoom' to manifest

### DIFF
--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -93,6 +93,6 @@
         }
     },
     "finsemble-electron-adapter": {
-        "disableZoom": true
+        "disableZoom": false
     }
 }

--- a/configs/application/manifest-local.json
+++ b/configs/application/manifest-local.json
@@ -91,5 +91,8 @@
                 }
             }
         }
+    },
+    "finsemble-electron-adapter": {
+        "disableZoom": true
     }
 }


### PR DESCRIPTION
refactor: #id [29253]

[Kanban link](https://chartiq.kanbanize.com/ctrl_board/18/cards/29253/details)

**Description of change**
* Added manifest variable: `finsemble-electron-adapter.disableZoom`, moving it out of FEA's window webPreferences

**Description of testing**
1. Test with FEA PR: https://github.com/ChartIQ/finsemble-electron-adapter/pull/282 and follow the testing steps