### PR TITLE
fix: #id 29519 Linker sometimes shows up at wrong position

### DIFF
--- a/src-built-in/components/linker/src/stores/linkerStore.js
+++ b/src-built-in/components/linker/src/stores/linkerStore.js
@@ -52,7 +52,13 @@ var LinkerStore = Object.assign({}, EventEmitter.prototype, {
 
 			self.setState(queryMessage.data);
 			// deal with the case of added linker channels
-			FSBL.Clients.WindowClient.fitToDOM();
+			const shownListener = () => {
+				finsembleWindow.removeEventListener("shown", shownListener);
+				console.log("launcherparams10", queryMessage.data);
+				FSBL.Clients.WindowClient.fitToDOM();
+			};
+			finsembleWindow.addEventListener("shown", shownListener);
+			
 			FSBL.Clients.Logger.system.log("toggle Linker window");
 			queryMessage.sendQueryResponse(null, {});
 		});

--- a/src-built-in/components/linker/src/stores/linkerStore.js
+++ b/src-built-in/components/linker/src/stores/linkerStore.js
@@ -54,7 +54,6 @@ var LinkerStore = Object.assign({}, EventEmitter.prototype, {
 			// deal with the case of added linker channels
 			const shownListener = () => {
 				finsembleWindow.removeEventListener("shown", shownListener);
-				console.log("launcherparams10", queryMessage.data);
 				FSBL.Clients.WindowClient.fitToDOM();
 			};
 			finsembleWindow.addEventListener("shown", shownListener);


### PR DESCRIPTION
https://cosaic.kanbanize.com/ctrl_board/106/cards/29519/details/

**Description of change**
* move fittodom call to after the window is shown

**Description of testing**
Markdown will convert the 1s to the appropriate number.
1. Arrange two windows like this: 
![image](https://user-images.githubusercontent.com/18012933/93494286-da76d000-f8da-11ea-8166-6d7ff8d2f5ea.png)
1. Alternately hit the linker button on both 50 times
1. Linker window always shows up on the correct window