### PR TITLE
Accept electron command line arguments from environment

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -354,6 +354,8 @@
 
 			// Copy any command line args from server-environment-startup.json
 			config.args = taskMethods.startupConfig[environment]["args"];
+			// Prepend any command line arguments from the environment
+			config.args = process.env.ELECTRON_ARGS + " " + (config.args || "");
 
 			if (!FEA) {
 				console.error("Could not launch ");

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -529,10 +529,10 @@
 			const extensions = fs.existsSync(path.join(__dirname, "server-extensions.js"))
 				? require("./server-extensions")
 				: {
-						pre: (done) => done(),
-						post: (done) => done(),
-						updateServer: (app, cb) => cb(),
-				  };
+					pre: (done) => done(),
+					post: (done) => done(),
+					updateServer: (app, cb) => cb(),
+				};
 
 			const root = path.join(__dirname, "public");
 			const port = process.env.PORT ? parseInt(process.env.PORT) : 3375;

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -355,7 +355,9 @@
 			// Copy any command line args from server-environment-startup.json
 			config.args = taskMethods.startupConfig[environment]["args"];
 			// Prepend any command line arguments from the environment
-			config.args = process.env.ELECTRON_ARGS + " " + (config.args || "");
+			if (!!process.env.ELECTRON_ARGS) {
+				config.args = process.env.ELECTRON_ARGS + " " + (config.args || "");
+			}
 
 			if (!FEA) {
 				console.error("Could not launch ");


### PR DESCRIPTION
This allows clients to specify command line arguments in an environment variable (ELECTRON_ARGS). 